### PR TITLE
Persistent open files leak fix

### DIFF
--- a/stringtools.cpp
+++ b/stringtools.cpp
@@ -1727,6 +1727,8 @@ std::string PrettyPrintTime(int64 ms)
 	unsigned int c_h=c_m*60;
 	unsigned int c_d=c_h*24;
 
+	int64 orig = ms;
+
 	if( ms>c_d)
 	{
 		int64 t=ms/c_d;
@@ -1757,6 +1759,12 @@ std::string PrettyPrintTime(int64 ms)
 		if(!ret.empty()) ret+=" ";
 		ret+=nconvert(t)+"s";
 		ms-=t*c_s;
+	}
+
+	if( orig < c_s)
+	{
+		if(!ret.empty()) ret+=" ";
+		ret+=nconvert(ms)+"ms";
 	}
 
 	return ret;

--- a/urbackupclient/ChangeJournalWatcher.cpp
+++ b/urbackupclient/ChangeJournalWatcher.cpp
@@ -1314,7 +1314,7 @@ void ChangeJournalWatcher::updateWithUsn(const std::wstring &vol, const SChangeJ
 				}
 				else
 				{
-					if(UsnRecord->Reason & USN_REASON_CLOSE)
+					if(UsnRecord->Reason & (USN_REASON_CLOSE | USN_REASON_RENAME_OLD_NAME))
 					{
 						std::map<std::wstring, bool>::iterator it_rf=local_open_write_files.find(real_fn);
 

--- a/urbackupclient/ChangeJournalWatcher.cpp
+++ b/urbackupclient/ChangeJournalWatcher.cpp
@@ -1049,6 +1049,7 @@ void ChangeJournalWatcher::update(std::wstring vol_str)
 
 void ChangeJournalWatcher::update_longliving(void)
 {
+	db->BeginTransaction();
 	if(!freeze_open_write_files)
 	{
 		std::vector<std::wstring> files = open_write_files.get();
@@ -1064,6 +1065,8 @@ void ChangeJournalWatcher::update_longliving(void)
 			listener->On_FileModified(it->first, true);
 		}
 	}
+	db->EndTransaction();
+
 	for(size_t i=0;i<error_dirs.size();++i)
 	{
 		listener->On_ResetAll(error_dirs[i]);

--- a/urbackupclient/PersistentOpenFiles.cpp
+++ b/urbackupclient/PersistentOpenFiles.cpp
@@ -255,6 +255,11 @@ void PersistentOpenFiles::add( const std::wstring& fn )
 	}
 }
 
+bool PersistentOpenFiles::is_present( const std::wstring& fn )
+{
+	return (open_files.find(fn)!=open_files.end());
+}
+
 PersistentOpenFiles::PersistentOpenFiles() : curr_id(0), bytes_written(0), bytes_deleted(0)
 {
 	persistf = Server->openFile(persistent_open_files_fn, MODE_RW_CREATE);

--- a/urbackupclient/PersistentOpenFiles.h
+++ b/urbackupclient/PersistentOpenFiles.h
@@ -23,6 +23,8 @@ public:
 
 	void remove(const std::wstring& fn);
 
+	bool is_present(const std::wstring& fn);
+
 	std::vector<std::wstring> get();
 
 	bool flushf();


### PR DESCRIPTION
This fixes a performance problem with (at least) incremental backups.  My incr backups were slower the longer it was since the last reboot.  Investigation showed the delay was proportional to the size of open_files.dat, with the indexing phase taking over an hour a week after a reboot instead of ~4 minutes seen immediately after a reboot.  The problem is that open_files.dat, and the in-memory representation in 'open_write_files', contains references to many files which are no longer open.  On my system, there should be around 300 open files, but after a week, we think there are about 90K open files.

Code in ChangeJournalWatcher.cpp failed to remove many files from open_write_files.  Most of that was because USN_REASON_RENAME_OLD_NAME should be treated like USN_REASON_CLOSE when handling a normal file, removing the file from open_write_files.

The other leak was a timing problem - if multiple USN change journal records for a single file are split across multiple calls to ChangeJournalWatcher::update(), the file might get added to open_write_files after the first update() call, but the USN records for the file in the second update() could be handled completely with local_open_write_files, not noticing that the file had already been added to open_write_files and should be removed on a close journal record.  Fix is, when adding a file to local_open_write_files, check whether the file is already in open_write_files, and if yes, remove it from both versions of the map when encountering a close journal record.

Including a compile minor changes.  First, PrettyPrintTime was returning an empty string for times less than a second.  Second, ChangeJournalWatcher::update_longliving should run its loops within a BeginTransaction/EndTransaction so the updates to the mfiles table are batched.