### PR TITLE
Python readall -> read

### DIFF
--- a/build/replace_versions.py
+++ b/build/replace_versions.py
@@ -67,7 +67,7 @@ def get_version(branch):
         else:
             print("Getting version failed. Retrying...")
     
-    data = response.readall();
+    data = response.read();
     
     response.close()
         


### PR DESCRIPTION
There was a problem with building server due to non existent function in python (version 3.5.2, tried also with 2.7)