### PR TITLE
Fix to SQL which prunes del_stats.

### DIFF
--- a/urbackupserver/server_cleanup.cpp
+++ b/urbackupserver/server_cleanup.cpp
@@ -1465,7 +1465,7 @@ bool ServerCleanupThread::deleteFileBackup(const std::string &backupfolder, int 
 			if(!b && SnapshotHelper::isSubvolume(clientname, backuppath) )
 			{
 				ServerLogger::Log(logid, "Deleting directory failed. Trying to truncate all files in subvolume to zero...", LL_ERROR);
-				b=truncate_files_recurisve(os_file_prefix(path));
+				b=truncate_files_recursive(os_file_prefix(path));
 
 				if(b)
 				{
@@ -1941,7 +1941,7 @@ bool ServerCleanupThread::isClientlistDeletionAllowed()
 	return allow_clientlist_deletion;
 }
 
-bool ServerCleanupThread::truncate_files_recurisve(std::string path)
+bool ServerCleanupThread::truncate_files_recursive(std::string path)
 {
 	std::vector<SFile> files=getFiles(path, NULL);
 
@@ -1949,7 +1949,7 @@ bool ServerCleanupThread::truncate_files_recurisve(std::string path)
 	{
 		if(files[i].isdir)
 		{
-			bool b=truncate_files_recurisve(path+os_file_sep()+files[i].name);
+			bool b=truncate_files_recursive(path+os_file_sep()+files[i].name);
 			if(!b)
 			{
 				return false;

--- a/urbackupserver/server_cleanup.h
+++ b/urbackupserver/server_cleanup.h
@@ -170,7 +170,7 @@ private:
 
 	int hasEnoughFreeSpace(int64 minspace, ServerSettings *settings);
 
-	bool truncate_files_recurisve(std::string path);
+	bool truncate_files_recursive(std::string path);
 
 	void enforce_quotas(void);
 


### PR DESCRIPTION
The SQL in cleanupLastActs doesn't seem to be working. Many of my nightly deletions are being cleaned up and therefore not shown in the morning.

I propose this SQL which is more deterministic. I know that it loops through each client, but performance isn't critical.

I'm not sure whether the index should be used or not, as it could be argued either way. The table is small and not performance critical, so I've removed it. Please retain it if you think it worthwhile.