### PR TITLE
Adding settings status symbols to installers for Linux / macOS

### DIFF
--- a/Makefile.am_client
+++ b/Makefile.am_client
@@ -174,7 +174,8 @@ install-data-local: urbackupclient/backup_scripts/list urbackupclient/backup_scr
 					urbackupclient/backup_scripts/mariadbxtrabackup.conf urbackupclient/backup_scripts/mariadbxtrabackup urbackupclient/backup_scripts/mariadbxtrabackup_incr \
 					client/info.txt client/data/backup-bad.ico client/data/backup-ok.ico client/data/backup-progress.ico \
 					client/data/backup-progress-pause.ico client/data/backup-no-server.ico client/data/backup-no-recent.ico client/data/backup-indexing.ico \
-					client/data/logo1.png client/data/lang/*/*.mo client/version.txt client/data/urbackup_ecdsa409k1.pub client/data/updates_h.dat
+					client/data/logo1.png client/data/lang/*/*.mo client/version.txt client/data/urbackup_ecdsa409k1.pub client/data/updates_h.dat \
+					client/fa-copy.png client/fa-home.png client/fa-lock.png client/fa-road.png
 else
 install-data-local: urbackupclient/backup_scripts/list urbackupclient/backup_scripts/list_incr urbackupclient/backup_scripts/mariadbdump.conf urbackupclient/backup_scripts/mariadbdump \
 					urbackupclient/backup_scripts/postgresqldump.conf urbackupclient/backup_scripts/postgresqldump \
@@ -182,7 +183,8 @@ install-data-local: urbackupclient/backup_scripts/list urbackupclient/backup_scr
 					urbackupclient/backup_scripts/mariadbxtrabackup.conf urbackupclient/backup_scripts/mariadbxtrabackup urbackupclient/backup_scripts/mariadbxtrabackup_incr \
 					client/info.txt client/data/backup-bad.xpm client/data/backup-ok.xpm client/data/backup-progress.xpm \
 					client/data/backup-progress-pause.xpm client/data/backup-no-server.xpm client/data/backup-no-recent.xpm client/data/backup-indexing.xpm \
-					client/data/logo1.png client/data/lang/*/*.mo client/version.txt client/data/urbackup_ecdsa409k1.pub client/data/updates_h.dat
+					client/data/logo1.png client/data/lang/*/*.mo client/version.txt client/data/urbackup_ecdsa409k1.pub client/data/updates_h.dat \
+					client/fa-copy.png client/fa-home.png client/fa-lock.png client/fa-road.png
 endif
 else
 install-data-local: urbackupclient/backup_scripts/list urbackupclient/backup_scripts/list_incr urbackupclient/backup_scripts/mariadbdump.conf urbackupclient/backup_scripts/mariadbdump \
@@ -225,6 +227,7 @@ endif
 if WITH_GUI_CLIENT
 	$(MKDIR_P) "$(DESTDIR)$(datadir)/urbackup"
 	$(INSTALL_DATA) $(srcdir)/client/data/*.png "$(DESTDIR)$(datadir)/urbackup/"
+	$(INSTALL_DATA) $(srcdir)/client/*.png "$(DESTDIR)$(datadir)/urbackup/"
 if MACOSX
 	$(INSTALL_DATA) $(srcdir)/client/data/*.ico "$(DESTDIR)$(datadir)/urbackup/"
 else


### PR DESCRIPTION
Looks like commit `ffeb034` in the client repo only affected Windows builds. This includes the settings status symbols in the Linux / macOS builds.