### PR TITLE
Update macOS paths

### DIFF
--- a/create_osx_installer.sh
+++ b/create_osx_installer.sh
@@ -19,7 +19,7 @@ mkdir -p osx-pkg/Library/LaunchDaemons
 cp osx_installer/daemon.plist osx-pkg/Library/LaunchDaemons/org.urbackup.client.plist
 mkdir -p osx-pkg/Library/LaunchAgents
 cp osx_installer/agent.plist osx-pkg/Library/LaunchAgents/org.urbackup.client.plist
-./configure --enable-embedded-cryptopp --enable-clientupdate CXXFLAGS="-mmacosx-version-min=10.6 -DNDEBUG -DURB_WITH_CLIENTUPDATE" CFLAGS="-DNDEBUG -DURB_WITH_CLIENTUPDATE" LDFLAGS="-mmacosx-version-min=10.6" --prefix="/Applications/UrBackup Client.app/Contents/MacOS"
+./configure --enable-embedded-cryptopp --enable-clientupdate CXXFLAGS="-mmacosx-version-min=10.9 -DNDEBUG -DURB_WITH_CLIENTUPDATE" CFLAGS="-DNDEBUG -DURB_WITH_CLIENTUPDATE" LDFLAGS="-mmacosx-version-min=10.9” --prefix="/Applications/UrBackup Client.app/Contents/MacOS" --sysconfdir="/Library/Application Support/UrBackup Client/etc" --localstatedir="/Library/Application Support/UrBackup Client/var"
 make clean
 make -j5
 make install DESTDIR=$PWD/osx-pkg2

--- a/osx_installer/agent.plist
+++ b/osx_installer/agent.plist
@@ -11,6 +11,6 @@
     <key>KeepAlive</key>
     <true/>
     <key>WorkingDirectory</key>
-    <string>Applications/UrBackup Client.app/Contents/MacOS/var</string>
+    <string>/Library/Application Support/UrBackup Client/var/</string>
 </dict>
 </plist>

--- a/osx_installer/daemon.plist
+++ b/osx_installer/daemon.plist
@@ -20,7 +20,7 @@
     <key>KeepAlive</key>
     <true/>
     <key>WorkingDirectory</key>
-    <string>/Applications/UrBackup Client.app/Contents/MacOS/var/</string>
+    <string>/Library/Application Support/UrBackup Client/var/</string>
     <key>HardResourceLimits</key>
     <dict>
         <key>NumberOfFiles</key>

--- a/osx_installer/scripts2/postinstall
+++ b/osx_installer/scripts2/postinstall
@@ -4,11 +4,11 @@ set -e
 
 if test -e "$1.cfg"
 then
-	cp "$1.cfg" "$2/Contents/MacOS/var/urbackup/initial_settings.cfg"
+	cp "$1.cfg" "/Library/Application Support/UrBackup Client/var/urbackup/initial_settings.cfg"
 
-	if test ! -e "$2/Contents/MacOS/var/urbackup/server_idents.txt"
+	if test ! -e "/Library/Application Support/UrBackup Client/var/urbackup/server_idents.txt"
 	then
-		cp "$1.ident" "$2/Contents/MacOS/var/urbackup/server_idents.txt"
+		cp "$1.ident" "/Library/Application Support/UrBackup Client/var/urbackup/server_idents.txt"
 	fi
 fi
 

--- a/osx_installer/scripts2/preinstall
+++ b/osx_installer/scripts2/preinstall
@@ -8,3 +8,23 @@ if /bin/launchctl list "org.urbackup.client.backend" &> /dev/null; then
 fi
 
 killall urbackupclientgui || true
+
+# Move var and etc folders to new location for macOS
+
+if test -e "$2/Contents/MacOS/var"
+then
+	if test -e "/Library/Application Support/UrBackup Client/var"
+	then
+		mv "/Library/Application Support/UrBackup Client/var" "/Library/Application Support/UrBackup Client/var_$(date "+%Y-%m-%d_%H%M%S")"
+	fi
+	mv "$2/Contents/MacOS/var" "/Library/Application Support/UrBackup Client/"
+fi
+
+if test -e "$2/Contents/MacOS/etc"
+then
+	if test -e "/Library/Application Support/UrBackup Client/etc"
+	then
+		mv "/Library/Application Support/UrBackup Client/etc" "/Library/Application Support/UrBackup Client/etc_$(date "+%Y-%m-%d_%H%M%S")"
+	fi
+	mv "$2/Contents/MacOS/etc" "/Library/Application Support/UrBackup Client/"
+fi


### PR DESCRIPTION
macOS should not have changing content inside the application bundle, so redirect the etc and var folders to `/Library/Application Support/UrBackup Client/` instead.

`create_osx_installer.sh` also updated to build for OS X 10.9 minimum