### PR TITLE
Add a development switch to the create_osx_installer script

### DIFF
--- a/create_osx_installer.sh
+++ b/create_osx_installer.sh
@@ -2,13 +2,23 @@
 
 set -e
 
-#Comment for development ----
-git reset --hard
-cd client
-git reset --hard
-cd ..
-python3 build/replace_versions.py
-#----
+development=false
+
+# Check if using development switch
+if [ "$1" != "" ]; then
+	if [[ "$1" == "-d" ]] || [[ "$1" == "--development" ]]; then
+		development=true
+	fi
+fi
+
+
+if !($development); then
+	git reset --hard
+	cd client
+	git reset --hard
+	cd ..
+	python3 build/replace_versions.py
+fi
 
 rm -R osx-pkg || true
 rm -R osx-pkg2 || true
@@ -27,7 +37,11 @@ mkdir -p "osx-pkg2/Applications/UrBackup Client.app/Contents/MacOS/bin"
 cp ../cocoasudo/build/Release/cocoasudo "osx-pkg2/Applications/UrBackup Client.app/Contents/MacOS/bin/UrBackup Client Administration"
 mkdir -p "osx-pkg2/Applications/UrBackup Client.app/Contents/MacOS"
 mkdir -p "osx-pkg2/Applications/UrBackup Client.app/Contents/Resources"
-cp osx_installer/info.plist "osx-pkg2/Applications/UrBackup Client.app/Contents/Info.plist"
+if !($development); then
+	cp osx_installer/info.plist "osx-pkg2/Applications/UrBackup Client.app/Contents/Info.plist"
+else
+	cp osx_installer/info_development.plist "osx-pkg2/Applications/UrBackup Client.app/Contents/Info.plist"
+fi
 cp osx_installer/urbackup.icns "osx-pkg2/Applications/UrBackup Client.app/Contents/Resources/"
 cp osx_installer/buildmacOSexclusions "osx-pkg2/Applications/UrBackup Client.app/Contents/MacOS/bin/buildmacOSexclusions"
 mv "osx-pkg2/Applications/UrBackup Client.app/Contents/MacOS/bin/urbackupclientgui" "osx-pkg2/Applications/UrBackup Client.app/Contents/MacOS/"
@@ -53,8 +67,13 @@ echo "OK=true" >> $UNINSTALLER
 
 chmod +x "$UNINSTALLER"
 
-VERSION_SHORT_NUM="$version_num_short$"
-VERSION_SHORT="$version_short$"
+if !($development); then
+	VERSION_SHORT_NUM="$version_num_short$"
+	VERSION_SHORT="$version_short$"
+else
+	VERSION_SHORT_NUM="0.1"
+	VERSION_SHORT="0.1"
+fi
 
 rm -R pkg1 || true
 mkdir pkg1 || true
@@ -62,19 +81,26 @@ pkgbuild --root osx-pkg --identifier org.urbackup.client.service --version $VERS
 pkgbuild --root "osx-pkg2/Applications/UrBackup Client.app" --identifier "org.urbackup.client" --version $VERSION_SHORT_NUM --scripts osx_installer/scripts2 --ownership recommended pkg1/output2.pkg --install-location "/Applications/UrBackup Client.app"
 productbuild --distribution osx_installer/distribution.xml --resources osx_installer/resources --package-path pkg1 --version $VERSION_SHORT_NUM final.pkg
 
-security unlock-keychain -p foobar /Users/martin/Library/Keychains/dev.keychain
-productsign --keychain /Users/martin/Library/Keychains/dev.keychain --sign 3Y4WACCWC5 final.pkg final-signed.pkg
+if !($development); then
+	security unlock-keychain -p foobar /Users/martin/Library/Keychains/dev.keychain
+	productsign --keychain /Users/martin/Library/Keychains/dev.keychain --sign 3Y4WACCWC5 final.pkg final-signed.pkg
 
-cp final-signed.pkg "UrBackup Client $VERSION_SHORT.pkg"
+	cp final-signed.pkg "UrBackup Client $VERSION_SHORT.pkg"
 
-mkdir -p update_installer
+	mkdir -p update_installer
 
-cp final-signed.pkg update_installer/final.pkg
-cp osx_installer/update_install.sh update_installer/update_install.sh
-chmod +x update_installer/update_install.sh
-makeself --nocomp --nomd5 --nocrc update_installer "UrBackupUpdateMac.sh" "UrBackup Client Installer for Mac OS X" ./update_install.sh
+	cp final-signed.pkg update_installer/final.pkg
+	cp osx_installer/update_install.sh update_installer/update_install.sh
+	chmod +x update_installer/update_install.sh
+	makeself --nocomp --nomd5 --nocrc update_installer "UrBackupUpdateMac.sh" "UrBackup Client Installer for Mac OS X" ./update_install.sh
+else
+	cp final.pkg "UrBackup Client $VERSION_SHORT.pkg"
+fi
 
-#Uncomment for development
-#sudo pkgutil --forget org.urbackup.client.service || true
-#sudo pkgutil --forget org.urbackup.client || true
-#sudo rm -R "/Applications/UrBackup Client.app" || true
+
+
+if ($development); then
+	sudo pkgutil --forget org.urbackup.client.service || true
+	sudo pkgutil --forget org.urbackup.client || true
+	sudo rm -R "/Applications/UrBackup Client.app" || true
+fi

--- a/osx_installer/info_development.plist
+++ b/osx_installer/info_development.plist
@@ -1,0 +1,32 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple Computer//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+  <key>CFBundleGetInfoString</key>
+  <string>UrBackup Client Tray Icon GUI</string>
+  <key>CFBundleExecutable</key>
+  <string>urbackupclientgui</string>
+  <key>CFBundleIdentifier</key>
+  <string>org.urbackup.client.frontend</string>
+  <key>CFBundleName</key>
+  <string>UrBackup Client</string>
+  <key>CFBundleIconFile</key>
+  <string>urbackup.icns</string>
+  <key>CFBundleVersion</key>
+  <string>0.1</string>
+  <key>CFBundleShortVersionString</key>
+  <string>0.1</string>
+  <key>CFBundleInfoDictionaryVersion</key>
+  <string>6.0</string>
+  <key>CFBundlePackageType</key>
+  <string>APPL</string>
+  <key>IFMajorVersion</key>
+  <integer>0</integer>
+  <key>IFMinorVersion</key>
+  <integer>1</integer>
+  <key>LSUIElement</key>
+  <string>1</string>
+  <key>LSMultipleInstancesProhibited</key>
+  <true />
+</dict>
+</plist>

--- a/readme-macos.md
+++ b/readme-macos.md
@@ -84,33 +84,16 @@ cd ~/UrBackup/urbackup_backend
 autoreconf -fvi
 ```
 
-For development, there are some changes that need to be manually applied:
-
-In `create_osx_installer.sh`:
-- Comment out lines 6-10, 64-65 and 75;
-- Replace lines 55-56 with this:
-```bash
-VERSION_SHORT_NUM="0.1"
-VERSION_SHORT="0.1"
-```
-In `osx_installer/info.plist`:
-- Replace lines 16, 18, 24 and 26 respectively with these:
-```bash
-<string>0.1</string>
-
-<string>0.1</string>
-
-<integer>0</integer>
-
-<integer>1</integer>
-```
-
-
-
 And then build it!
 ```bash
 cd ~/UrBackup/urbackup_backend
 ./create_osx_installer.sh
+```
+
+For development, use the `-d` or `--development` switches
+```bash
+cd ~/UrBackup/urbackup_backend
+./create_osx_installer.sh -d
 ```
 
 


### PR DESCRIPTION
Automates certain changes required for building the macOS version in a development environment