### PR TITLE
Correct the path to the build_macos_exclusions script

### DIFF
--- a/osx_installer/scripts2/postinstall
+++ b/osx_installer/scripts2/postinstall
@@ -29,4 +29,4 @@ else
 	done
 fi
 
-"$2/Contents/MacOS/buildmacOSexclusions"
+"$2/Contents/MacOS/bin/buildmacOSexclusions"


### PR DESCRIPTION
Correct the path to the build_macos_exclusions script, as called from the installer postinstall script