### PR TITLE
Fix macOS uninstaller

### DIFF
--- a/osx_installer/uninstall1.sh
+++ b/osx_installer/uninstall1.sh
@@ -4,9 +4,10 @@ set -e
 set -x
 
 function finish {
-	if [[ $OK == "true" ]]
+	if [[ $OK == true ]]
 	then
 		osascript -e 'display notification "UrBackup was uninstalled successfully." with title "UrBackup"'
+		killall urbackupclientgui || true
 	else
 		osascript -e 'display notification "Failed to uninstall UrBackup" with title "UrBackup"'
 	fi
@@ -18,8 +19,6 @@ if /bin/launchctl list "org.urbackup.client.backend" &> /dev/null; then
 	/bin/launchctl stop "org.urbackup.client.backend" 
     /bin/launchctl unload "/Library/LaunchDaemons/org.urbackup.client.plist"
 fi
-
-killall urbackupclientgui || true
 
 /Applications/UrBackup\ Client.app/Contents/MacOS/urbackupclientgui remove_login_item
 


### PR DESCRIPTION
Correct typo in finish function, and move gui kill command to end of process (preventing a premature exit of the script)