### PR TITLE
update client repo path

### DIFF
--- a/checkout_client.bat
+++ b/checkout_client.bat
@@ -1,6 +1,6 @@
 for /f "delims=" %%i in ('git rev-parse --abbrev-ref HEAD') do set BRANCH=%%i
 
-if not exist client git clone -b %BRANCH% http://buildserver.urbackup.org/git/urbackup_frontend_wx client
+if not exist client git clone -b %BRANCH% https://github.com/uroni/urbackup_frontend_wx client
 
 cd client
 


### PR DESCRIPTION
checkout_client.bat helper still pointed at "http://buildserver.urbackup.org/git/urbackup_frontend_wx" which returned HTTP 403 Forbidden. Switched it to current repository on github: https://github.com/uroni/urbackup_frontend_wx