### PR TITLE
Move the Application Support folder into osx-pkg before packaging

### DIFF
--- a/create_osx_installer.sh
+++ b/create_osx_installer.sh
@@ -53,6 +53,8 @@ else
 fi
 cp osx_installer/urbackup.icns "osx-pkg2/Applications/UrBackup Client.app/Contents/Resources/"
 cp osx_installer/buildmacOSexclusions "osx-pkg2/Applications/UrBackup Client.app/Contents/MacOS/bin/buildmacOSexclusions"
+mv "osx-pkg2/Library/Application Support" "osx-pkg/Library"
+rm -R "osx-pkg2/Library"
 mv "osx-pkg2/Applications/UrBackup Client.app/Contents/MacOS/bin/urbackupclientgui" "osx-pkg2/Applications/UrBackup Client.app/Contents/MacOS/"
 strip "osx-pkg2/Applications/UrBackup Client.app/Contents/MacOS/urbackupclientgui"
 strip "osx-pkg2/Applications/UrBackup Client.app/Contents/MacOS/sbin/urbackupclientbackend"


### PR DESCRIPTION
The _Application Support_ folder was being omitted by the pkgbuild stage for osx-pkg2, so move it into osx-pkg instead.