### PR TITLE
Update backend to compile in MacOS High Sierra.

### DIFF
--- a/blockalign_src/main.cpp
+++ b/blockalign_src/main.cpp
@@ -50,12 +50,10 @@
 #include "crc.h"
 #endif
 
-#if defined(__FreeBSD__)
+#if defined(__FreeBSD__) || defined(__APPLE__)
 #define lstat64 lstat
 #define stat64 stat
 #define fstat64 fstat
-#define open64 open
-#elif defined(__APPLE__)
 #define open64 open
 #endif
 

--- a/blockalign_src/main.cpp
+++ b/blockalign_src/main.cpp
@@ -50,10 +50,12 @@
 #include "crc.h"
 #endif
 
-#if defined(__FreeBSD__) || defined(__APPLE__)
+#if defined(__FreeBSD__)
 #define lstat64 lstat
 #define stat64 stat
 #define fstat64 fstat
+#define open64 open
+#elif defined(__APPLE__)
 #define open64 open
 #endif
 

--- a/file_linux.cpp
+++ b/file_linux.cpp
@@ -87,13 +87,24 @@ namespace
 #endif
 #endif //__linux__
 
-#if defined(__FreeBSD__) || defined(__APPLE__)
+#if defined(__FreeBSD__)
 #define open64 open
 #define off64_t off_t
 #define lseek64 lseek
 #define O_LARGEFILE 0
 #define stat64 stat
 #define fstat64 fstat
+#define ftruncate64 ftruncate
+#define fallocate64 fallocate
+#define pwrite64 pwrite
+#define pread64 pread
+#elif defined(__APPLE__)
+#define open64 open
+#define off64_t off_t
+#define lseek64 lseek
+#define O_LARGEFILE 0
+//#define stat64 stat
+//#define fstat64 fstat
 #define ftruncate64 ftruncate
 #define fallocate64 fallocate
 #define pwrite64 pwrite

--- a/file_linux.cpp
+++ b/file_linux.cpp
@@ -87,24 +87,13 @@ namespace
 #endif
 #endif //__linux__
 
-#if defined(__FreeBSD__)
+#if defined(__FreeBSD__) || defined(__APPLE__)
 #define open64 open
 #define off64_t off_t
 #define lseek64 lseek
 #define O_LARGEFILE 0
 #define stat64 stat
 #define fstat64 fstat
-#define ftruncate64 ftruncate
-#define fallocate64 fallocate
-#define pwrite64 pwrite
-#define pread64 pread
-#elif defined(__APPLE__)
-#define open64 open
-#define off64_t off_t
-#define lseek64 lseek
-#define O_LARGEFILE 0
-//#define stat64 stat
-//#define fstat64 fstat
 #define ftruncate64 ftruncate
 #define fallocate64 fallocate
 #define pwrite64 pwrite

--- a/fileservplugin/CClientThread.cpp
+++ b/fileservplugin/CClientThread.cpp
@@ -49,7 +49,7 @@
 #endif
 #include <assert.h>
 
-#if defined(__APPLE__) || defined(__FreeBSD__)
+#if defined(__FreeBSD__)
 #include <sys/uio.h>
 #define open64 open
 #define off64_t off_t
@@ -57,14 +57,19 @@
 #define O_LARGEFILE 0
 #define stat64 stat
 #define fstat64 fstat
-
-#if defined(__FreeBSD__)
 #define sendfile64(a, b, c, d, e) sendfile(a, b, c, d, NULL, e, 0)
-#else
-#define sendfile64(a, b, c, d, e) sendfile(a, b, c, e, NULL, 0)
-#endif
+#endif	// defined(__FreeBSD__)
 
-#endif
+#if defined(__APPLE__)
+#include <sys/uio.h>
+#define open64 open
+#define off64_t off_t
+#define lseek64 lseek
+#define O_LARGEFILE 0
+//#define stat64 stat
+//#define fstat64 fstat
+#define sendfile64(a, b, c, d, e) sendfile(a, b, c, e, NULL, 0)
+#endif	// defined(__APPLE__)
 
 #include "FileMetadataPipe.h"
 

--- a/fileservplugin/CClientThread.cpp
+++ b/fileservplugin/CClientThread.cpp
@@ -49,7 +49,7 @@
 #endif
 #include <assert.h>
 
-#if defined(__FreeBSD__)
+#if defined(__APPLE__) || defined(__FreeBSD__)
 #include <sys/uio.h>
 #define open64 open
 #define off64_t off_t
@@ -57,19 +57,14 @@
 #define O_LARGEFILE 0
 #define stat64 stat
 #define fstat64 fstat
-#define sendfile64(a, b, c, d, e) sendfile(a, b, c, d, NULL, e, 0)
-#endif	// defined(__FreeBSD__)
 
-#if defined(__APPLE__)
-#include <sys/uio.h>
-#define open64 open
-#define off64_t off_t
-#define lseek64 lseek
-#define O_LARGEFILE 0
-//#define stat64 stat
-//#define fstat64 fstat
+#if defined(__FreeBSD__)
+#define sendfile64(a, b, c, d, e) sendfile(a, b, c, d, NULL, e, 0)
+#else
 #define sendfile64(a, b, c, d, e) sendfile(a, b, c, e, NULL, 0)
-#endif	// defined(__APPLE__)
+#endif
+
+#endif
 
 #include "FileMetadataPipe.h"
 

--- a/fileservplugin/FileMetadataPipe.cpp
+++ b/fileservplugin/FileMetadataPipe.cpp
@@ -47,8 +47,8 @@
 #if defined(__APPLE__)
 #define llistxattr(path, list, size) listxattr(path, list, size, XATTR_NOFOLLOW)
 #define lgetxattr(path, name, value, size) getxattr(path, name, value, size, 0, XATTR_NOFOLLOW)
-//#define stat64 stat
-//#define lstat64 lstat
+#define stat64 stat
+#define lstat64 lstat
 #endif
 
 #if defined(__FreeBSD__)

--- a/fileservplugin/FileMetadataPipe.cpp
+++ b/fileservplugin/FileMetadataPipe.cpp
@@ -47,8 +47,8 @@
 #if defined(__APPLE__)
 #define llistxattr(path, list, size) listxattr(path, list, size, XATTR_NOFOLLOW)
 #define lgetxattr(path, name, value, size) getxattr(path, name, value, size, 0, XATTR_NOFOLLOW)
-#define stat64 stat
-#define lstat64 lstat
+//#define stat64 stat
+//#define lstat64 lstat
 #endif
 
 #if defined(__FreeBSD__)

--- a/fileservplugin/FileMetadataPipe.cpp
+++ b/fileservplugin/FileMetadataPipe.cpp
@@ -47,8 +47,6 @@
 #if defined(__APPLE__)
 #define llistxattr(path, list, size) listxattr(path, list, size, XATTR_NOFOLLOW)
 #define lgetxattr(path, name, value, size) getxattr(path, name, value, size, 0, XATTR_NOFOLLOW)
-#define stat64 stat
-#define lstat64 lstat
 #endif
 
 #if defined(__FreeBSD__)

--- a/fileservplugin/PipeFileTar.h
+++ b/fileservplugin/PipeFileTar.h
@@ -7,7 +7,7 @@
 #include <sys/stat.h>
 #include "../stringtools.h"
 
-#if defined(_WIN32) || defined(__FreeBSD__)
+#if defined(_WIN32) || defined(__APPLE__) || defined(__FreeBSD__)
 #define stat64 stat
 #endif
 

--- a/fileservplugin/PipeFileTar.h
+++ b/fileservplugin/PipeFileTar.h
@@ -7,7 +7,7 @@
 #include <sys/stat.h>
 #include "../stringtools.h"
 
-#if defined(_WIN32) || defined(__APPLE__) || defined(__FreeBSD__)
+#if defined(_WIN32) || defined(__FreeBSD__)
 #define stat64 stat
 #endif
 

--- a/urbackupcommon/os_functions_lin.cpp
+++ b/urbackupcommon/os_functions_lin.cpp
@@ -51,19 +51,9 @@
 #endif
 #include <stack>
 
-#if defined(__FreeBSD__)
+#if defined(__FreeBSD__) || defined(__APPLE__)
 #define lstat64 lstat
 #define stat64 stat
-#define statvfs64 statvfs
-#define open64 open
-#define readdir64 readdir
-#define dirent64 dirent
-#define fsblkcnt64_t fsblkcnt_t
-#endif
-
-#if defined(__APPLE__)
-//#define lstat64 lstat
-//#define stat64 stat
 #define statvfs64 statvfs
 #define open64 open
 #define readdir64 readdir
@@ -387,12 +377,8 @@ int64 os_free_space(const std::string &path)
     int rc=statvfs64((path).c_str(), &buf);
 	if(rc==0)
 	{
-#if defined(__FreeBSD__) || defined(__APPLE__)
-		int64 free = (int64)buf.f_frsize*buf.f_bavail;
-#else
 		fsblkcnt64_t blocksize = buf.f_frsize ? buf.f_frsize : buf.f_bsize;
 		fsblkcnt64_t free = blocksize*buf.f_bavail;
-#endif
 		if(free>LLONG_MAX)
 		{
 			return LLONG_MAX;
@@ -420,11 +406,7 @@ int64 os_total_space(const std::string &path)
 	if(rc==0)
 	{
 		fsblkcnt64_t used=buf.f_blocks-buf.f_bfree;
-#if defined(__FreeBSD__) || defined(__APPLE__)
-		int64 total = (int64)(used+buf.f_bavail)*buf.f_frsize;
-#else
 		fsblkcnt64_t total = (used+buf.f_bavail)*buf.f_bsize;
-#endif
 		if(total>LLONG_MAX)
 		{
 			return LLONG_MAX;

--- a/urbackupcommon/os_functions_lin_min.cpp
+++ b/urbackupcommon/os_functions_lin_min.cpp
@@ -44,10 +44,6 @@
 #define lstat64 lstat
 #endif
 
-#if defined(__APPLE__)
-#define open64 open
-#endif
-
 
 void getMousePos(int &x, int &y)
 {

--- a/urbackupcommon/os_functions_lin_min.cpp
+++ b/urbackupcommon/os_functions_lin_min.cpp
@@ -44,6 +44,10 @@
 #define lstat64 lstat
 #endif
 
+#if defined(__APPLE__)
+#define open64 open
+#endif
+
 
 void getMousePos(int &x, int &y)
 {

--- a/urbackupserver/copy_storage.cpp
+++ b/urbackupserver/copy_storage.cpp
@@ -32,7 +32,7 @@
 #include "server_log.h"
 #include "server_status.h"
 
-#if defined(_WIN32) || defined(__APPLE__) || defined(__FreeBSD__)
+#if defined(_WIN32) || defined(__FreeBSD__)
 #define stat64 stat
 #endif
 


### PR DESCRIPTION
Fixed compilation errors on Mac OS High Sierra.
Also added important fix for BSD variants, caused by a critic semantic difference in the `statvfs` results call (Linux vs BSD), causing wrong free disk space calculation. This also causes a truncation error.