### PR TITLE
Fixed Crashes in MacOS X client App

### DIFF
--- a/create_osx_installer.sh
+++ b/create_osx_installer.sh
@@ -1,4 +1,4 @@
-#!/usr/local/bin/bash
+#!/usr/bin/env bash
 
 set -e
 
@@ -39,7 +39,11 @@ mkdir -p osx-pkg/Library/LaunchDaemons
 cp osx_installer/daemon.plist osx-pkg/Library/LaunchDaemons/org.urbackup.client.plist
 mkdir -p osx-pkg/Library/LaunchAgents
 cp osx_installer/agent.plist osx-pkg/Library/LaunchAgents/org.urbackup.client.plist
-./configure --enable-embedded-cryptopp --enable-clientupdate CXXFLAGS="-mmacosx-version-min=10.10 -DNDEBUG -DURB_WITH_CLIENTUPDATE" CFLAGS="-DNDEBUG -DURB_WITH_CLIENTUPDATE" LDFLAGS="-mmacosx-version-min=10.10" --prefix="/Applications/UrBackup Client.app/Contents/MacOS" --sysconfdir="/Library/Application Support/UrBackup Client/etc" --localstatedir="/Library/Application Support/UrBackup Client/var"
+if !($development); then
+	./configure --enable-embedded-cryptopp --enable-clientupdate CXXFLAGS="-mmacosx-version-min=10.10 -DNDEBUG -DURB_WITH_CLIENTUPDATE" CFLAGS="-DNDEBUG -DURB_WITH_CLIENTUPDATE" LDFLAGS="-mmacosx-version-min=10.10" --prefix="/Applications/UrBackup Client.app/Contents/MacOS" --sysconfdir="/Library/Application Support/UrBackup Client/etc" --localstatedir="/Library/Application Support/UrBackup Client/var"
+else
+	./configure --enable-embedded-cryptopp --enable-clientupdate CXXFLAGS="-mmacosx-version-min=10.10 -DDEBUG -DURB_WITH_CLIENTUPDATE -O0 -g" CFLAGS="-DDEBUG -DURB_WITH_CLIENTUPDATE -O0 -g" LDFLAGS="-mmacosx-version-min=10.10" --prefix="/Applications/UrBackup Client.app/Contents/MacOS" --sysconfdir="/Library/Application Support/UrBackup Client/etc" --localstatedir="/Library/Application Support/UrBackup Client/var"
+fi
 make clean
 make -j5
 make install DESTDIR=$PWD/osx-pkg2
@@ -56,8 +60,10 @@ cp osx_installer/buildmacOSexclusions "osx-pkg2/Applications/UrBackup Client.app
 mv "osx-pkg2/Library/Application Support" "osx-pkg/Library"
 rm -R "osx-pkg2/Library"
 mv "osx-pkg2/Applications/UrBackup Client.app/Contents/MacOS/bin/urbackupclientgui" "osx-pkg2/Applications/UrBackup Client.app/Contents/MacOS/"
-strip "osx-pkg2/Applications/UrBackup Client.app/Contents/MacOS/urbackupclientgui"
-strip "osx-pkg2/Applications/UrBackup Client.app/Contents/MacOS/sbin/urbackupclientbackend"
+if !($development); then
+	strip "osx-pkg2/Applications/UrBackup Client.app/Contents/MacOS/urbackupclientgui"
+	strip "osx-pkg2/Applications/UrBackup Client.app/Contents/MacOS/sbin/urbackupclientbackend"
+fi
 
 mkdir -p "$PWD/osx-pkg2/Applications/UrBackup Client.app/Contents/MacOS/sbin"
 UNINSTALLER="$PWD/osx-pkg2/Applications/UrBackup Client.app/Contents/MacOS/sbin/urbackup_uninstall"

--- a/fileservplugin/CUDPThread.cpp
+++ b/fileservplugin/CUDPThread.cpp
@@ -114,7 +114,7 @@ std::string getSystemServerName(bool use_fqdn)
 			Server->wait(100);
 		}
 	}
-#endif
+#else
 
     _i32 rc=gethostname(hostname, MAX_PATH);
 
@@ -154,6 +154,7 @@ std::string getSystemServerName(bool use_fqdn)
 	}
 
 	return ret;
+#endif
 }
 
 bool CUDPThread::hasError(void)

--- a/urbackupclient/ClientService.cpp
+++ b/urbackupclient/ClientService.cpp
@@ -600,7 +600,13 @@ bool ClientConnector::Run(IRunOtherCallback* p_run_other)
 
 					if(crypto_fak!=NULL)
 					{
-						if (crypto_fak->verifyFile(UPDATE_SIGNATURE_PREFIX "urbackup_ecdsa409k1.pub",
+#if defined(__APPLE__)
+						// ./UrBackup\ Client.app/Contents/MacOS/sbin/../share/urbackup/urbackup_ecdsa409k1.pub
+						std::string pubkey = ExtractFilePath(Server->getServerWorkingDir()) + "/share/urbackup/urbackup_ecdsa409k1.pub";
+#else
+						std::string pubkey = UPDATE_SIGNATURE_PREFIX "urbackup_ecdsa409k1.pub";
+#endif
+						if (crypto_fak->verifyFile(pubkey,
 							UPDATE_FILE_PREFIX "UrBackupUpdate_untested.dat", UPDATE_FILE_PREFIX "UrBackupUpdate.sig2"))
 						{
 							std::auto_ptr<IFile> updatefile(Server->openFile(UPDATE_FILE_PREFIX "UrBackupUpdate_untested.dat"));

--- a/urbackupclient/cmdline_preprocessor.cpp
+++ b/urbackupclient/cmdline_preprocessor.cpp
@@ -350,7 +350,13 @@ int main(int argc, char* argv[])
 		real_args.push_back("--workingdir");
 		real_args.push_back(VARDIR);
 		real_args.push_back("--script_path");
+#if defined(__APPLE__)
+		// ./UrBackup\ Client.app/Contents/MacOS/bin/urbackupclientctl../../share/urbackup/scripts
+		std::string datadir = ExtractFilePath(ExtractFilePath(argv[0])) + "/share/urbackup/scripts";
+		real_args.push_back( datadir + ":" SYSCONFDIR "/urbackup/scripts");
+#else
 		real_args.push_back( DATADIR "/urbackup/scripts:" SYSCONFDIR "/urbackup/scripts");
+#endif
 		real_args.push_back("--pidfile");
 		real_args.push_back(pidfile_arg.getValue());
 		if(std::find(real_args.begin(), real_args.end(), "--logfile")==real_args.end())


### PR DESCRIPTION
Fixed Application bundle relative paths for OS build. The use of absolute paths causes Exceptions, depending on Bundle install location.
Should be combined with the Pull Request in **uroni/urbackup_frontend_wx**. 