### PR TITLE
Hardcode DataVault paths into buildmacOSexclusions script

### DIFF
--- a/osx_installer/buildmacOSexclusions
+++ b/osx_installer/buildmacOSexclusions
@@ -77,6 +77,12 @@ for item in $user_paths_excluded; do
 	fi
 done
 
+# Hardcode paths for DataVaults
+
+paths_excluded_array+=("/Users/*/Library/VoiceTrigger/SAT")
+paths_excluded_array+=("/Users/*/Library/Containers/com.apple.mail/Data/DataVaults")
+paths_excluded_array+=("/var/folders/*/*/*/com.apple.nsurlsessiond")
+
 
 set -f
 sorted_array=($(sort <<<"${paths_excluded_array[*]}"))


### PR DESCRIPTION
On macOS, DataVaults cannot be read by unauthorised applications, so should be excluded from backups.
Paths taken from here: https://eclecticlight.co/2018/10/25/no-entry-⛔%EF%B8%8F-access-controls-in-mojave/