### PR TITLE
Add NSPrincipalClass key to macOS Info.plist

### DIFF
--- a/osx_installer/info.plist
+++ b/osx_installer/info.plist
@@ -29,6 +29,6 @@
   <key>LSMultipleInstancesProhibited</key>
   <true />
   <key>NSPrincipalClass</key>
-	<string>wxNSApplication</string>
+  <string>wxNSApplication</string>
 </dict>
 </plist>

--- a/osx_installer/info.plist
+++ b/osx_installer/info.plist
@@ -28,5 +28,7 @@
   <string>1</string>
   <key>LSMultipleInstancesProhibited</key>
   <true />
+  <key>NSPrincipalClass</key>
+	<string>wxNSApplication</string>
 </dict>
 </plist>


### PR DESCRIPTION
Currently, the GUI is blurry, due to WxWidgets not using High-DPI assets by default. This should fix that.