### PR TITLE
Fixes typo in Swedish translation

### DIFF
--- a/urbackupserver/www/translations/urbackup.webinterface/sv.po
+++ b/urbackupserver/www/translations/urbackup.webinterface/sv.po
@@ -747,7 +747,7 @@ msgid "tChange password"
 msgstr "Ändra lösenord"
 
 msgid "tSeparate settings for this client"
-msgstr "Sepparata inställningar för denna klient"
+msgstr "Separata inställningar för denna klient"
 
 msgid "tArchival"
 msgstr "Arkivering"


### PR DESCRIPTION
'separate' is typed 'separata' in Swedish.