### PR TITLE
Change request content-type in getJSON

### DIFF
--- a/urbackupserver/www/js/urbackup_functions.js
+++ b/urbackupserver/www/js/urbackup_functions.js
@@ -238,7 +238,7 @@ getJSON = function(action, parameters, callback)
 	{ url: getURL(action),
 	  dataType: "json",
 	  method: "POST",
-	  contentType:"application/json; charset=utf-8",
+	  contentType:"application/x-www-form-urlencoded; charset=utf-8",
 	  data: parameters
 	}
 	).done(function(data)


### PR DESCRIPTION
The current content-type for requests in getJSON is application/json, yet the data is formatted as application/x-www-form-urlencoded, which can cause issues (at least for me) with reverse proxies with body parsing/handling.