### PR TITLE
Add some more logging during database upgrade checks

### DIFF
--- a/urbackupserver/dllmain.cpp
+++ b/urbackupserver/dllmain.cpp
@@ -2395,7 +2395,7 @@ void upgrade(void)
 
 	if(qp==NULL)
 	{
-	    Server->Log("db_version is still not there, abrorting upgrade", LL_WARNING);
+	    Server->Log("db_version is still not there, aborting upgrade", LL_WARNING);
 	    return;
 	}
 

--- a/urbackupserver/dllmain.cpp
+++ b/urbackupserver/dllmain.cpp
@@ -2381,7 +2381,7 @@ bool upgrade65_66()
 
 void upgrade(void)
 {
-    Server->Log("Check for necessary database updates...");
+    Server->Log("Check for necessary database updates...", LL_WARNING);
 
 	Server->destroyAllDatabases();
 	IDatabase *db=Server->getDatabase(Server->getThreadID(), URBACKUPDB_SERVER);
@@ -2455,7 +2455,7 @@ void upgrade(void)
 				" You need a newer UrBackup server version to work with this database.", LL_ERROR);
 			exit(4);
 		} else {
-		    Server->Log("No (more) database upgrade needed.");
+		    Server->Log("No (more) database upgrade needed.", LL_WARNING);
 		}
 
 		db->BeginWriteTransaction();

--- a/urbackupserver/dllmain.cpp
+++ b/urbackupserver/dllmain.cpp
@@ -2388,11 +2388,15 @@ void upgrade(void)
 	IQuery *qp=db->Prepare("SELECT tvalue FROM misc WHERE tkey='db_version'");
 	if(qp==NULL)
 	{
-		Server->Log("Importing data...");
+		Server->Log("Importing data, because db_version is not there...", LL_WARNING);
 		db->Import("urbackup/backup_server.dat");
 		qp=db->Prepare("SELECT tvalue FROM misc WHERE tkey='db_version'");
+	}
 
-		return;
+	if(qp==NULL)
+	{
+	    Server->Log("db_version is still not there, abrorting upgrade", LL_WARNING);
+	    return;
 	}
 
 	db_results res_v=qp->Read();

--- a/urbackupserver/dllmain.cpp
+++ b/urbackupserver/dllmain.cpp
@@ -2455,7 +2455,7 @@ void upgrade(void)
 				" You need a newer UrBackup server version to work with this database.", LL_ERROR);
 			exit(4);
 		} else {
-		    Server->Log("No database upgrade needed.");
+		    Server->Log("No (more) database upgrade needed.");
 		}
 
 		db->BeginWriteTransaction();


### PR DESCRIPTION
This change adds some more informational log entries regarding database upgrade check.

I did not tested it. If something is wrong, I would adapt the patch as needed.