### PR TITLE
Fix settings save with multiple server addresses

### DIFF
--- a/urbackupserver/www/js/urbackup.js
+++ b/urbackupserver/www/js/urbackup.js
@@ -4413,7 +4413,7 @@ function getInternetSettings()
 
 	if(internet_servers[0].indexOf(";")!=-1)
 	{
-		internet_servers = internet_servers.split(";");
+		internet_servers = internet_servers[0].split(";");
 	}
 	
 	var internet_server_par = "";


### PR DESCRIPTION
This is a fix for a bug that results in:

1. For new installations - unable to configure multiple addresses for internet server via web UI.
2. For upgraded installations - unable to save settings (any settings) via web UI when multiple servers are configured.
