### PR TITLE
Fix path creation in dattobd_remove_snapshot 

### DIFF
--- a/linux_snapshot/dattobd_remove_snapshot
+++ b/linux_snapshot/dattobd_remove_snapshot
@@ -9,22 +9,27 @@ SNAP_ORIG_PATH_SAN=$(echo "$SNAP_ORIG_PATH" | sed 's@/@_@g')
 
 CDIR=`dirname $0`
 
+get_path()
+{
+        echo $1/$2 | sed 's@//@/@g'
+}
+
 remove_overlay() {
-	if test -e "$SNAP_ORIG_PATH/.overlay_2fefd007-3e48-4162-b2c6-45ccdda22f37_$SNAP_ID"
+	if test -e $(get_path "$SNAP_ORIG_PATH" "/.overlay_2fefd007-3e48-4162-b2c6-45ccdda22f37_$SNAP_ID")
 	then
-		LODEV=`losetup -j "$SNAP_ORIG_PATH/.overlay_2fefd007-3e48-4162-b2c6-45ccdda22f37_$SNAP_ID" | cut -d':' -f1`
+		LODEV=`losetup -j $(get_path "$SNAP_ORIG_PATH" "/.overlay_2fefd007-3e48-4162-b2c6-45ccdda22f37_$SNAP_ID") | cut -d':' -f1`
 		if [ "x$LODEV" != x ]
 		then
 			losetup -d $LODEV
 		fi
-		rm "$SNAP_ORIG_PATH/.overlay_2fefd007-3e48-4162-b2c6-45ccdda22f37_$SNAP_ID"
+		rm $(get_path "$SNAP_ORIG_PATH" "/.overlay_2fefd007-3e48-4162-b2c6-45ccdda22f37_$SNAP_ID")
 	fi
 }
 
 if ! test -e $SNAP_MOUNTPOINT
 then
     echo "Snapshot at $SNAP_MOUNTPOINT was already removed"
-    [ ! -e "$SNAP_ORIG_PATH/.datto_3d41c58e-6724-4d47-8981-11c766a08a24_$SNAP_ID" ] || rm "$SNAP_ORIG_PATH/.datto_3d41c58e-6724-4d47-8981-11c766a08a24_$SNAP_ID"
+    [ ! -e $(get_path "$SNAP_ORIG_PATH" "/.datto_3d41c58e-6724-4d47-8981-11c766a08a24_$SNAP_ID") ] || rm $(get_path "$SNAP_ORIG_PATH" "/.datto_3d41c58e-6724-4d47-8981-11c766a08a24_$SNAP_ID")
     [ ! -e "${SNAP_MOUNTPOINT}-num" ] || rm "${SNAP_MOUNTPOINT}-num"
 	remove_overlay
     exit 0
@@ -51,7 +56,7 @@ then
     echo "Snapshot is not mounted. Already removed"
     rm "${SNAP_MOUNTPOINT}-num"
     rmdir "${SNAP_MOUNTPOINT}"
-    [ ! -e "$SNAP_ORIG_PATH/.datto_3d41c58e-6724-4d47-8981-11c766a08a24_$SNAP_ID" ] || rm "$SNAP_ORIG_PATH/.datto_3d41c58e-6724-4d47-8981-11c766a08a24_$SNAP_ID"
+    [ ! -e $(get_path "$SNAP_ORIG_PATH" "/.datto_3d41c58e-6724-4d47-8981-11c766a08a24_$SNAP_ID") ] || rm $(get_path "$SNAP_ORIG_PATH" "/.datto_3d41c58e-6724-4d47-8981-11c766a08a24_$SNAP_ID")
     remove_overlay
     exit 0
 fi


### PR DESCRIPTION
Same fix as for the create script: Fixes cases where root "/" gets concatenated with "/.datto..." resulting in paths beginning with a double slash "//.datto..."