### PR TITLE
Change fallback path to /usr/lib/systemd for unit dir

### DIFF
--- a/install_client_linux.sh
+++ b/install_client_linux.sh
@@ -312,8 +312,8 @@ then
 	
 	if [ "x$SYSTEMD_DIR" = x ]
 	then
-		echo "Cannot find systemd unit dir. Assuming /lib/systemd/system"
-		SYSTEMD_DIR="/lib/systemd/system"
+		echo "Cannot find systemd unit dir. Assuming /usr/lib/systemd/system"
+		SYSTEMD_DIR="/usr/lib/systemd/system"
 	fi
 	
 	install -c urbackupclientbackend.service $SYSTEMD_DIR


### PR DESCRIPTION
Should work for more systems according to:
https://unix.stackexchange.com/questions/224992/where-do-i-put-my-systemd-unit-file