### PR TITLE
Compile fix for crc.h

### DIFF
--- a/blockalign_src/crc.h
+++ b/blockalign_src/crc.h
@@ -7,6 +7,7 @@
 #pragma once
 
 #include <string>
+#include <cstdint>
 
 namespace cryptopp_crc
 {


### PR DESCRIPTION
Hello

This PR fixes a missing library that some reason causes "nota: uintptr_t is defined in header <cstdint>; did you forget to #include <cstdint>?"

Tested on Fedora 39