### PR TITLE
include <cstdint> in blockalign_src to provide uintptr_t

### DIFF
--- a/blockalign_src/crc.cpp
+++ b/blockalign_src/crc.cpp
@@ -6,6 +6,8 @@
 #include <setjmp.h>
 #endif
 
+#include <cstdint> // for uintptr_t data type
+
 // Visual Studio needs VS2008 (1500)
 //  http://msdn.microsoft.com/en-us/library/bb531394%28v=vs.90%29.aspx
 #if defined(_MSC_VER) && (_MSC_VER < 1500)


### PR DESCRIPTION
On my system, compiling urbackup-client causes error 

```
blockalign_src/crc.cpp: In function ‘bool cryptopp_crc::IsAlignedOn(const void*, unsigned int)’:
blockalign_src/crc.cpp:191:23: error: ‘uintptr_t’ does not name a type
  191 |                 const uintptr_t x = reinterpret_cast<uintptr_t>(ptr);
```

This change fixes this error