### PR TITLE
EscapeHTML: Fix potentially vulnerable missing semicolon

### DIFF
--- a/stringtools.cpp
+++ b/stringtools.cpp
@@ -1256,7 +1256,7 @@ std::string EscapeHTML(const std::string & html)
 		else if (html[i] == '&') ret += "&amp;";
 		else if (html[i] == '\"') ret += "&quot;";
 		else if (html[i] == '\'') ret += "&#x27;";
-		else if (html[i] == '/') ret += "&#x2F";
+		else if (html[i] == '/') ret += "&#x2F;";
 		else ret += html[i];
 	}
 	return ret;


### PR DESCRIPTION
This patch fixes a missing semicolon in `stringtools:EscapeHTML`, specifically in the entity code for forward slash characters.

This is theoretically exploitable in some way, as the following payload:

`test/81;string`

will be escaped as:

`test&#x2F81;string`

Whenever this is unescaped, whether on the server, client, as a result of a server admin investigating log file, or in any other relevant circumstances, it will result in the following string:

`test⾁string`

This is a contrived example but there are many other code points in Unicode, meaning that it's difficult to fully eliminate the possibility of this being exploitable in some context, for example in a situation where a code point may affect the terminal being outputted to in some way.

---

Additionally, line ending mismatches in `getStreamFile` have been updated automatically by the GitHub edit or, so these are included in the patch.