### PR TITLE
UI

### DIFF
--- a/urbackupserver/www2/package.json
+++ b/urbackupserver/www2/package.json
@@ -20,6 +20,7 @@
     "@lingui/core": "^4.10.1",
     "@lingui/react": "^4.10.1",
     "@tanstack/react-query": "^5.56.2",
+    "@tanstack/react-query-devtools": "^5.61.5",
     "@types/crypto-js": "^4.2.2",
     "crypto-js": "^4.2.0",
     "react": "^18.3.1",

--- a/urbackupserver/www2/pnpm-lock.yaml
+++ b/urbackupserver/www2/pnpm-lock.yaml
@@ -29,6 +29,9 @@ importers:
       '@tanstack/react-query':
         specifier: ^5.56.2
         version: 5.56.2(react@18.3.1)
+      '@tanstack/react-query-devtools':
+        specifier: ^5.61.5
+        version: 5.61.5(@tanstack/react-query@5.56.2(react@18.3.1))(react@18.3.1)
       '@types/crypto-js':
         specifier: ^4.2.2
         version: 4.2.2
@@ -1355,6 +1358,15 @@ packages:
 
   '@tanstack/query-core@5.56.2':
     resolution: {integrity: sha512-gor0RI3/R5rVV3gXfddh1MM+hgl0Z4G7tj6Xxpq6p2I03NGPaJ8dITY9Gz05zYYb/EJq9vPas/T4wn9EaDPd4Q==}
+
+  '@tanstack/query-devtools@5.61.4':
+    resolution: {integrity: sha512-21Tw+u8E3IJJj4A/Bct4H0uBaDTEu7zBrR79FeSyY+mS2gx5/m316oDtJiKkILc819VSTYt+sFzODoJNcpPqZQ==}
+
+  '@tanstack/react-query-devtools@5.61.5':
+    resolution: {integrity: sha512-P2DwlKyoGar6FX2XL324gM7AX8fuXm6DecLvfUoGpWbxtbuAtfzglRiCDLKkc5tJ7pekuaZsFFas/cyfTymoCQ==}
+    peerDependencies:
+      '@tanstack/react-query': ^5.61.5
+      react: ^18 || ^19
 
   '@tanstack/react-query@5.56.2':
     resolution: {integrity: sha512-SR0GzHVo6yzhN72pnRhkEFRAHMsUo5ZPzAxfTMvUxFIDVS6W9LYUp6nXW3fcHVdg0ZJl8opSH85jqahvm6DSVg==}
@@ -4704,6 +4716,14 @@ snapshots:
       tslib: 2.6.2
 
   '@tanstack/query-core@5.56.2': {}
+
+  '@tanstack/query-devtools@5.61.4': {}
+
+  '@tanstack/react-query-devtools@5.61.5(@tanstack/react-query@5.56.2(react@18.3.1))(react@18.3.1)':
+    dependencies:
+      '@tanstack/query-devtools': 5.61.4
+      '@tanstack/react-query': 5.56.2(react@18.3.1)
+      react: 18.3.1
 
   '@tanstack/react-query@5.56.2(react@18.3.1)':
     dependencies:

--- a/urbackupserver/www2/src/App.tsx
+++ b/urbackupserver/www2/src/App.tsx
@@ -14,6 +14,7 @@ import {
   Spinner,
   Toaster,
 } from "@fluentui/react-components";
+import { ReactQueryDevtools } from "@tanstack/react-query-devtools";
 import { useStackStyles } from "./components/StackStyles";
 import UrBackupServer, { SessionNotFoundError } from "./api/urbackupserver";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
@@ -191,6 +192,8 @@ const App: React.FunctionComponent = () => {
               </div>
             </div>
             <Toaster toasterId="toaster" />
+            {/* Following only bundled in development mode */}
+            <ReactQueryDevtools initialIsOpen={false} />
           </QueryClientProvider>
         </I18nProvider>
       </React.StrictMode>

--- a/urbackupserver/www2/src/App.tsx
+++ b/urbackupserver/www2/src/App.tsx
@@ -25,6 +25,7 @@ import { ClientBackupsTable } from "./features/backups/ClientBackupsTable";
 import { BackupsTable } from "./features/backups/BackupsTable";
 import { BackupContentTable } from "./features/backups/BackupContentTable";
 import BackupErrorPage from "./features/backups/BackupsError";
+import "./css/global.css";
 
 const initialDark =
   window.matchMedia &&

--- a/urbackupserver/www2/src/App.tsx
+++ b/urbackupserver/www2/src/App.tsx
@@ -20,6 +20,11 @@ import UrBackupServer, { SessionNotFoundError } from "./api/urbackupserver";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { i18n } from "@lingui/core";
 import { I18nProvider } from "@lingui/react";
+import { BackupsPage } from "./pages/Backups";
+import { ClientBackupsTable } from "./features/backups/ClientBackupsTable";
+import { BackupsTable } from "./features/backups/BackupsTable";
+import { BackupContentTable } from "./features/backups/BackupContentTable";
+import BackupErrorPage from "./features/backups/BackupsError";
 
 const initialDark =
   window.matchMedia &&
@@ -29,6 +34,7 @@ const initialTheme = initialDark ? teamsDarkTheme : teamsLightTheme;
 export enum Pages {
   Status = "status",
   Activities = "activities",
+  Backups = "backups",
   Login = "login",
   About = "about",
 }
@@ -110,6 +116,30 @@ export const router = createHashRouter([
       await jumpToLoginPageIfNeccessary();
       return null;
     },
+  },
+  {
+    path: `/${Pages.Backups}`,
+    element: <BackupsPage />,
+    loader: async () => {
+      state.pageAfterLogin = Pages.Backups;
+      await jumpToLoginPageIfNeccessary();
+      return null;
+    },
+    errorElement: <BackupErrorPage />,
+    children: [
+      {
+        index: true,
+        element: <BackupsTable />,
+      },
+      {
+        path: ":clientId",
+        element: <ClientBackupsTable />,
+      },
+      {
+        path: ":clientId/:backupId",
+        element: <BackupContentTable />,
+      },
+    ],
   },
 ]);
 

--- a/urbackupserver/www2/src/api/urbackupserver.ts
+++ b/urbackupserver/www2/src/api/urbackupserver.ts
@@ -155,7 +155,7 @@ interface BackupsErr {
   err: string | "access_denied" | undefined;
 }
 
-interface BackupsClient {
+export interface BackupsClient {
   id: number; // client id
   lastbackup: number; // unix timestamp
   name: string; // name of client
@@ -165,7 +165,7 @@ interface BackupsClients {
   clients: BackupsClient[];
 }
 
-interface Backup {
+export interface Backup {
   id: number; // Backup id
   size_bytes: number; // Size of backup in bytes
   incremental: number; // !=0 if this is a incremental backup
@@ -188,7 +188,7 @@ interface Backups {
   clientid: number; // Id of the client
 }
 
-interface File {
+export interface File {
   name: string; // Name of the file
   dir: boolean; // If true this is a directory
   mod: number; // Unix timestamp of last modification
@@ -580,7 +580,7 @@ class UrBackupServer {
     clientid: number,
     backupid: number,
     path: string,
-    mount: boolean,
+    mount?: boolean,
   ) => {
     const resp = await this.fetchData(
       {

--- a/urbackupserver/www2/src/components/Breadcrumbs.tsx
+++ b/urbackupserver/www2/src/components/Breadcrumbs.tsx
@@ -1,0 +1,231 @@
+/**
+ * Adapted from https://react.fluentui.dev/?path=/docs/components-breadcrumb--docs#breadcrumb-with-tooltip
+ */
+
+import React, { Fragment } from "react";
+import {
+  Breadcrumb as FUIBreadcrumb,
+  BreadcrumbItem,
+  BreadcrumbButton,
+  BreadcrumbDivider,
+  partitionBreadcrumbItems,
+  truncateBreadcrumbLongName,
+  isTruncatableBreadcrumbContent,
+  Tooltip,
+  useIsOverflowItemVisible,
+  Menu,
+  MenuTrigger,
+  useOverflowMenu,
+  MenuPopover,
+  MenuList,
+  Button,
+  MenuItemLink,
+  tokens,
+} from "@fluentui/react-components";
+import {
+  MoreHorizontalRegular,
+  MoreHorizontalFilled,
+  bundleIcon,
+} from "@fluentui/react-icons";
+import type { PartitionBreadcrumbItems } from "@fluentui/react-components";
+
+export type BreadcrumbItem = {
+  key: string | number;
+  text: string;
+  itemProps: {
+    href: string;
+  };
+};
+
+const MAX_TEXT_LENGTH = 30;
+const MAX_DISPLAYED_ITEMS = 6;
+
+export const BASE_HREF = `${window.location.origin}/#` as const;
+
+const MoreHorizontal = bundleIcon(MoreHorizontalFilled, MoreHorizontalRegular);
+
+const styles = {
+  breadcrumbText: {
+    fontWeight: tokens.fontWeightRegular,
+    margin: 0,
+  },
+  breadcrumbTextLast: {
+    fontWeight: tokens.fontWeightBold,
+    margin: 0,
+  },
+  tooltip: {
+    whiteSpace: "nowrap",
+    overflow: "hidden",
+    textOverflow: "ellipsis",
+  },
+};
+
+function renderItem(
+  entry: BreadcrumbItem,
+  isLastItem: boolean,
+  wrapper?: React.ElementType<{ children: React.ReactNode }>,
+) {
+  const ButtonWrapper = wrapper ?? "span";
+
+  return (
+    <Fragment key={`item-${entry.key}`}>
+      {isTruncatableBreadcrumbContent(entry.text, MAX_TEXT_LENGTH) ? (
+        <BreadcrumbItem>
+          <Tooltip withArrow content={entry.text} relationship="label">
+            <BreadcrumbButton current={isLastItem} href={entry.itemProps?.href}>
+              <ButtonWrapper
+                style={
+                  isLastItem ? styles.breadcrumbTextLast : styles.breadcrumbText
+                }
+              >
+                {truncateBreadcrumbLongName(entry.text)}
+              </ButtonWrapper>
+            </BreadcrumbButton>
+          </Tooltip>
+        </BreadcrumbItem>
+      ) : (
+        <BreadcrumbItem>
+          <BreadcrumbButton current={isLastItem} href={entry.itemProps?.href}>
+            <ButtonWrapper
+              style={
+                isLastItem ? styles.breadcrumbTextLast : styles.breadcrumbText
+              }
+            >
+              {entry.text}
+            </ButtonWrapper>
+          </BreadcrumbButton>
+        </BreadcrumbItem>
+      )}
+
+      {!isLastItem && <BreadcrumbDivider />}
+    </Fragment>
+  );
+}
+
+function BreadcrumbMenuItem({ item }: { item: BreadcrumbItem }) {
+  const isVisible = useIsOverflowItemVisible(item.key.toString());
+
+  if (isVisible) {
+    return null;
+  }
+
+  return <MenuItemLink href={item.itemProps?.href}>{item.text}</MenuItemLink>;
+}
+
+function MenuWithTooltip({
+  overflowItems,
+  startDisplayedItems,
+  endDisplayedItems,
+}: PartitionBreadcrumbItems<BreadcrumbItem>) {
+  const { ref, isOverflowing, overflowCount } =
+    useOverflowMenu<HTMLButtonElement>();
+
+  if (!isOverflowing && overflowItems && overflowItems.length === 0) {
+    return null;
+  }
+
+  const overflowItemsCount = overflowItems
+    ? overflowItems.length + overflowCount
+    : overflowCount;
+
+  const tooltipContent = {
+    children:
+      overflowItemsCount > 3
+        ? `${overflowItemsCount} items`
+        : getTooltipContent(overflowItems),
+    style: styles.tooltip,
+  };
+
+  return (
+    <Menu hasIcons>
+      <MenuTrigger disableButtonEnhancement>
+        <Tooltip withArrow content={tooltipContent} relationship="label">
+          <Button
+            id="menu"
+            appearance="subtle"
+            ref={ref}
+            icon={<MoreHorizontal />}
+            aria-label={`${overflowItemsCount} more items`}
+            role="button"
+          />
+        </Tooltip>
+      </MenuTrigger>
+      <MenuPopover>
+        <MenuList>
+          {isOverflowing &&
+            startDisplayedItems.map((item: BreadcrumbItem) => (
+              <BreadcrumbMenuItem item={item} key={item.key} />
+            ))}
+          {overflowItems &&
+            overflowItems.map((item: BreadcrumbItem) => (
+              <BreadcrumbMenuItem item={item} key={item.key} />
+            ))}
+          {isOverflowing &&
+            endDisplayedItems &&
+            endDisplayedItems.map((item: BreadcrumbItem) => (
+              <BreadcrumbMenuItem item={item} key={item.key} />
+            ))}
+        </MenuList>
+      </MenuPopover>
+    </Menu>
+  );
+}
+
+const getTooltipContent = (
+  breadcrumbItems: readonly BreadcrumbItem[] | undefined,
+) => {
+  if (!breadcrumbItems) {
+    return "";
+  }
+  return breadcrumbItems.reduce(
+    (acc, initialValue, _idx, arr) => {
+      return (
+        <>
+          {acc}
+          {arr[0].text !== initialValue.text && " > "}
+          {initialValue.text}
+        </>
+      );
+    },
+    <Fragment />,
+  );
+};
+
+export function Breadcrumbs({
+  items,
+  wrapper,
+}: {
+  items: BreadcrumbItem[];
+  wrapper?: React.ElementType<{ children: React.ReactNode }>;
+}) {
+  const {
+    startDisplayedItems,
+    overflowItems,
+    endDisplayedItems,
+  }: PartitionBreadcrumbItems<BreadcrumbItem> = partitionBreadcrumbItems({
+    items,
+    maxDisplayedItems: MAX_DISPLAYED_ITEMS,
+  });
+
+  return (
+    <FUIBreadcrumb aria-label="breadcrumb">
+      {startDisplayedItems.map((item) => renderItem(item, false, wrapper))}
+
+      {overflowItems && (
+        <>
+          <MenuWithTooltip
+            overflowItems={overflowItems}
+            startDisplayedItems={startDisplayedItems}
+            endDisplayedItems={endDisplayedItems}
+          />
+          <BreadcrumbDivider />
+        </>
+      )}
+
+      {endDisplayedItems &&
+        endDisplayedItems.map((item, index, array) =>
+          renderItem(item, index === array.length - 1, wrapper),
+        )}
+    </FUIBreadcrumb>
+  );
+}

--- a/urbackupserver/www2/src/components/NavSidebar.tsx
+++ b/urbackupserver/www2/src/components/NavSidebar.tsx
@@ -19,6 +19,7 @@ export const NavSidebar = () => {
     <TabList selectedValue={snap.activePage} vertical onTabSelect={onTabSelect}>
       <Tab value={Pages.Status}>Status</Tab>
       <Tab value={Pages.Activities}>Activities</Tab>
+      <Tab value={Pages.Backups}>Backups</Tab>
     </TabList>
   );
 };

--- a/urbackupserver/www2/src/components/TableWrapper.tsx
+++ b/urbackupserver/www2/src/components/TableWrapper.tsx
@@ -1,0 +1,3 @@
+export function TableWrapper({ children }: { children: React.ReactNode }) {
+  return <section>{children}</section>;
+}

--- a/urbackupserver/www2/src/components/TableWrapper.tsx
+++ b/urbackupserver/www2/src/components/TableWrapper.tsx
@@ -1,3 +1,3 @@
 export function TableWrapper({ children }: { children: React.ReactNode }) {
-  return <section>{children}</section>;
+  return <section className="flow table-wrapper">{children}</section>;
 }

--- a/urbackupserver/www2/src/css/global.css
+++ b/urbackupserver/www2/src/css/global.css
@@ -1,0 +1,16 @@
+@import url("reset.css") layer(reset);
+
+@layer composition {
+  /* 
+  FLOW COMPOSITION 
+  Like the Every Layout stack: https://every-layout.dev/layouts/stack/
+  Info about this implementation: https://piccalil.li/quick-tip/flow-utility/ 
+  */
+  .flow > * + * {
+    margin-top: var(--flow-space, 1em);
+  }
+}
+
+.table-wrapper {
+  --flow-space: 1.5em;
+}

--- a/urbackupserver/www2/src/css/global.css
+++ b/urbackupserver/www2/src/css/global.css
@@ -14,3 +14,15 @@
 .table-wrapper {
   --flow-space: 1.5em;
 }
+
+[role="gridcell"]:has(a) {
+  align-items: normal;
+}
+
+[role="gridcell"] a {
+  color: inherit;
+  text-decoration: none;
+  display: flex;
+  align-items: center;
+  width: 100%;
+}

--- a/urbackupserver/www2/src/css/reset.css
+++ b/urbackupserver/www2/src/css/reset.css
@@ -1,0 +1,91 @@
+/* Adapted from Modern reset: https://piccalil.li/blog/a-more-modern-css-reset/ */
+
+/* Box sizing rules */
+*,
+*::before,
+*::after {
+  box-sizing: border-box;
+}
+
+/* Prevent font size inflation */
+html {
+  -moz-text-size-adjust: none;
+  -webkit-text-size-adjust: none;
+  text-size-adjust: none;
+}
+
+/* Remove default margin in favour of better control in authored CSS */
+body,
+h1,
+h2,
+h3,
+h4,
+p,
+figure,
+blockquote,
+dl,
+dd {
+  margin-block: 0;
+}
+
+/* Remove list styles on ul, ol elements */
+ul,
+ol {
+  list-style: none;
+}
+
+/* Set core body defaults */
+body {
+  min-height: 100vh;
+  line-height: 1.5;
+}
+
+/* Set shorter line heights on headings and interactive elements */
+h1,
+h2,
+h3,
+h4,
+button,
+input,
+label {
+  line-height: 1.1;
+}
+
+/* Balance text wrapping on headings */
+h1,
+h2,
+h3,
+h4 {
+  text-wrap: balance;
+}
+
+/* A elements that don't have a class get default styles */
+a:not([class]) {
+  text-decoration-skip-ink: auto;
+  color: currentColor;
+}
+
+/* Make images easier to work with */
+img,
+picture {
+  max-width: 100%;
+  display: block;
+}
+
+/* Inherit fonts for inputs and buttons */
+input,
+button,
+textarea,
+select {
+  font: inherit;
+}
+
+/* Make sure textareas without a rows attribute are not tiny */
+textarea:not([rows]) {
+  min-height: 10em;
+}
+
+/* Anything that has been anchored to should have extra scroll margin */
+:target {
+  scroll-margin-block: 5ex;
+}

--- a/urbackupserver/www2/src/features/activities/LastActivitiesTable.tsx
+++ b/urbackupserver/www2/src/features/activities/LastActivitiesTable.tsx
@@ -58,7 +58,7 @@ export const columns: TableColumnDefinition<ActivityItem>[] = [
   createTableColumn<ActivityItem>({
     columnId: "backuptime",
     renderHeaderCell: () => {
-      return "Starting Time";
+      return "Starting time";
     },
     renderCell: (item) => {
       return (
@@ -69,7 +69,7 @@ export const columns: TableColumnDefinition<ActivityItem>[] = [
   createTableColumn<ActivityItem>({
     columnId: "duration",
     renderHeaderCell: () => {
-      return "Required Time";
+      return "Required time";
     },
     renderCell: (item) => {
       return <TableCellLayout>{formatDuration(item.duration)}</TableCellLayout>;

--- a/urbackupserver/www2/src/features/activities/OngoingActivitiesTable.tsx
+++ b/urbackupserver/www2/src/features/activities/OngoingActivitiesTable.tsx
@@ -9,7 +9,6 @@ import {
   TableColumnDefinition,
   createTableColumn,
   TableColumnId,
-  DataGridCellFocusMode,
   Field,
   ProgressBar,
   tokens,
@@ -22,6 +21,7 @@ import { format_size, formatDuration } from "../../utils/format";
 import { NUMBERED_ACTIONS_MAP } from "./ACTIONS";
 import { OngoingActivitiesActions } from "./OngoingActivitiesActions";
 import { ProcessSpeedChart } from "./ProcessSpeedChart";
+import { getCellFocusMode } from "../../utils/table";
 
 const styles: Record<string, React.CSSProperties> = {
   progressField: {
@@ -152,15 +152,6 @@ export const columns: TableColumnDefinition<ProcessItem>[] = [
     },
   }),
 ];
-
-const getCellFocusMode = (columnId: TableColumnId): DataGridCellFocusMode => {
-  switch (columnId) {
-    case "actions":
-      return "group";
-    default:
-      return "cell";
-  }
-};
 
 export function OngoingActivitiesTable({ data }: { data: ProcessItem[] }) {
   if (data.length === 0) {

--- a/urbackupserver/www2/src/features/backups/ArchiveCheckbox.tsx
+++ b/urbackupserver/www2/src/features/backups/ArchiveCheckbox.tsx
@@ -1,0 +1,84 @@
+import { Caption1, Caption1Strong, Checkbox } from "@fluentui/react-components";
+import { useMutation, useQueryClient } from "@tanstack/react-query";
+
+import { Backup } from "../../api/urbackupserver";
+import { urbackupServer } from "../../App";
+import { formatDatetime } from "../../utils/format";
+
+function useArchiveBackupMutation() {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: ({
+      clientId,
+      backupId,
+    }: {
+      clientId: number;
+      backupId: number;
+    }) => urbackupServer.archiveBackup(clientId, backupId),
+    onSuccess: (_, variables) => {
+      return queryClient.invalidateQueries({
+        queryKey: ["backups", variables.clientId],
+      });
+    },
+  });
+}
+
+function useUnarchiveBackupMutation() {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: ({
+      clientId,
+      backupId,
+    }: {
+      clientId: number;
+      backupId: number;
+    }) => urbackupServer.unarchiveBackup(clientId, backupId),
+    onSuccess: (_, variables) => {
+      return queryClient.invalidateQueries({
+        queryKey: ["backups", variables.clientId],
+      });
+    },
+  });
+}
+
+export function ArchiveCheckbox(item: Backup & { clientid: number }) {
+  const isArchived = item.archived === 1;
+
+  const archiveBackupMutation = useArchiveBackupMutation();
+
+  const unarchiveBackupMutation = useUnarchiveBackupMutation();
+
+  return (
+    <>
+      <Checkbox
+        checked={isArchived}
+        onChange={(_, data) => {
+          if (data.checked) {
+            archiveBackupMutation.mutate({
+              clientId: item.clientid,
+              backupId: item.id,
+            });
+
+            return;
+          }
+
+          unarchiveBackupMutation.mutate({
+            clientId: item.clientid,
+            backupId: item.id,
+          });
+        }}
+      />
+
+      {!!item.archive_timeout && (
+        <Caption1 block>
+          Unarchives on{" "}
+          <Caption1Strong block>
+            {formatDatetime(item.archive_timeout)}
+          </Caption1Strong>
+        </Caption1>
+      )}
+    </>
+  );
+}

--- a/urbackupserver/www2/src/features/backups/BackupContentTable.tsx
+++ b/urbackupserver/www2/src/features/backups/BackupContentTable.tsx
@@ -1,0 +1,295 @@
+import {
+  DataGrid,
+  DataGridHeader,
+  DataGridRow,
+  DataGridHeaderCell,
+  DataGridBody,
+  DataGridCell,
+  TableCellLayout,
+  TableColumnDefinition,
+  createTableColumn,
+  makeStyles,
+  Button,
+  TableColumnId,
+  tokens,
+} from "@fluentui/react-components";
+import { useParams, useSearchParams } from "react-router-dom";
+import { useSuspenseQuery } from "@tanstack/react-query";
+import { Document20Filled, Folder20Filled } from "@fluentui/react-icons";
+
+import type { File } from "../../api/urbackupserver";
+import { getCellFocusMode } from "../../utils/table";
+import { format_size, formatDatetime } from "../../utils/format";
+import { urbackupServer } from "../../App";
+import { Breadcrumbs } from "../../components/Breadcrumbs";
+import { makeBackupsBreadcrumbs } from "./makeBackupsBreadcrumbs";
+import { TableWrapper } from "../../components/TableWrapper";
+
+const useStyles = makeStyles({
+  cell: {
+    alignItems: "unset",
+  },
+  link: {
+    color: "inherit",
+    textDecoration: "none",
+    display: "flex",
+    alignItems: "center",
+    width: "100%",
+  },
+  heading: {
+    display: "flex",
+    gap: tokens.spacingHorizontalM,
+    // Negate the margin top and left values
+    // to keep breadcrumbs aligned to initial top-left position
+    marginInlineStart: "-7px",
+    marginBlockStart: "-7px",
+  },
+  headingAction: {
+    marginInlineStart: "auto",
+  },
+});
+
+const tableStyles = {
+  name: {
+    display: "flex",
+    gap: tokens.spacingHorizontalS,
+    alignItems: "center",
+  },
+  file: {
+    color: tokens.colorBrandBackground,
+  },
+};
+
+export const columns: TableColumnDefinition<File>[] = [
+  createTableColumn<File>({
+    columnId: "name",
+    renderHeaderCell: () => {
+      return "Name";
+    },
+    renderCell: (item) => {
+      return (
+        <TableCellLayout>
+          <span style={tableStyles.name}>
+            {item.dir ? (
+              <Folder20Filled />
+            ) : (
+              <Document20Filled style={tableStyles.file} />
+            )}
+            {item.name}
+          </span>
+        </TableCellLayout>
+      );
+    },
+  }),
+  createTableColumn<File>({
+    columnId: "size",
+    renderHeaderCell: () => {
+      return "Size";
+    },
+    renderCell: (item) => {
+      return (
+        <TableCellLayout>
+          {item.size ? format_size(item.size) : ""}
+        </TableCellLayout>
+      );
+    },
+  }),
+  createTableColumn<File>({
+    columnId: "created",
+    renderHeaderCell: () => {
+      return "Created";
+    },
+    renderCell: (item) => {
+      if (!item.creat) {
+        return "-";
+      }
+
+      return <TableCellLayout>{formatDatetime(item.creat)}</TableCellLayout>;
+    },
+  }),
+  createTableColumn<File>({
+    columnId: "mod",
+    renderHeaderCell: () => {
+      return "Last modified";
+    },
+    renderCell: (item) => {
+      if (!item.mod) {
+        return "-";
+      }
+
+      return <TableCellLayout>{formatDatetime(item.mod)}</TableCellLayout>;
+    },
+  }),
+  createTableColumn<File>({
+    columnId: "access",
+    renderHeaderCell: () => {
+      return "Last accessed";
+    },
+    renderCell: (item) => {
+      if (!item.access) {
+        return "-";
+      }
+
+      return <TableCellLayout>{formatDatetime(item.access)}</TableCellLayout>;
+    },
+  }),
+  createTableColumn<File>({
+    columnId: "actions",
+    renderHeaderCell: () => "",
+    renderCell: () => {
+      return <Button>List</Button>;
+    },
+  }),
+];
+
+const noneColumns = ["name", "size", "created", "mod", "access"];
+
+export function BackupContentTable() {
+  const { clientId, backupId } = useParams();
+  const [searchParams, setSearchParams] = useSearchParams();
+
+  const path = searchParams.get("path");
+
+  const { data, error, isFetching } = useSuspenseQuery({
+    queryKey: [
+      "backups",
+      Number(clientId),
+      Number(backupId),
+      // Create unique keys for each path to save path files in cache for quick load
+      ...(path ?? "").split("/").filter(Boolean),
+    ],
+    queryFn: () =>
+      urbackupServer.getFiles(Number(clientId), Number(backupId), path ?? "/"),
+    retry: 1,
+  });
+
+  const classes = useStyles();
+
+  const { clientname, backuptime, files } = data;
+
+  const breadcrumbItems = makeBackupsBreadcrumbs({
+    clientId: Number(clientId),
+    backupId: Number(backupId),
+    backuptime,
+    clientName: clientname!,
+    path,
+  });
+
+  if (error && !isFetching) {
+    throw error;
+  }
+
+  if (files.length === 0) {
+    return (
+      <TableWrapper>
+        <div className={classes.heading}>
+          <Breadcrumbs items={breadcrumbItems} wrapper={"h3"} />
+        </div>
+        <p>No files exist in this path.</p>
+      </TableWrapper>
+    );
+  }
+
+  return (
+    <TableWrapper>
+      <div className={classes.heading}>
+        <Breadcrumbs items={breadcrumbItems} wrapper={"h3"} />
+        <Button
+          appearance="primary"
+          className={classes.headingAction}
+          onClick={() => {
+            const folderPath = path ?? "/";
+            if (folderPath) {
+              location.href = urbackupServer.downloadZipURL(
+                Number(clientId),
+                Number(backupId),
+                folderPath,
+              );
+            }
+          }}
+        >
+          Download Folder as ZIP
+        </Button>
+      </div>
+      <DataGrid items={files} getRowId={(item) => item.id} columns={columns}>
+        <DataGridHeader>
+          <DataGridRow>
+            {({ renderHeaderCell, columnId }) => (
+              <DataGridHeaderCell style={getNarrowColumnStyles(columnId)}>
+                {renderHeaderCell()}
+              </DataGridHeaderCell>
+            )}
+          </DataGridRow>
+        </DataGridHeader>
+        <DataGridBody<File>>
+          {({ item }) => (
+            <DataGridRow<File>>
+              {({ renderCell, columnId }) => {
+                const isInteractive = ["actions"].includes(String(columnId));
+
+                return (
+                  <DataGridCell
+                    focusMode={getCellFocusMode(columnId, {
+                      group: ["actions"],
+                      none: noneColumns,
+                    })}
+                    className={isInteractive ? "" : classes.cell}
+                    style={getNarrowColumnStyles(columnId)}
+                  >
+                    {isInteractive ? (
+                      renderCell(item)
+                    ) : (
+                      <a
+                        href=""
+                        onClick={(e) => {
+                          e.preventDefault();
+
+                          // Navigate to new path if item is a directory
+                          if (item.dir) {
+                            const params = {
+                              path: `${path ?? ""}/${item.name}`,
+                            };
+
+                            setSearchParams(params);
+
+                            return;
+                          }
+
+                          if (path) {
+                            const filePath = `${path}/${item.name}`;
+                            location.href = urbackupServer.downloadFileURL(
+                              Number(clientId),
+                              Number(backupId),
+                              filePath,
+                            );
+                          }
+                        }}
+                        className={classes.link}
+                      >
+                        {renderCell(item)}
+                      </a>
+                    )}
+                  </DataGridCell>
+                );
+              }}
+            </DataGridRow>
+          )}
+        </DataGridBody>
+      </DataGrid>
+    </TableWrapper>
+  );
+}
+
+const narrowColumnIds = ["size", "created", "mod", "access", "actions"];
+
+/**
+ * Style some columns to take up less space.
+ */
+function getNarrowColumnStyles(columnId: TableColumnId) {
+  const stringId = columnId.toString();
+
+  return {
+    flexGrow: narrowColumnIds.includes(stringId) ? "0" : "1",
+    flexBasis: narrowColumnIds.includes(stringId) ? "17ch" : "0",
+  };
+}

--- a/urbackupserver/www2/src/features/backups/BackupContentTable.tsx
+++ b/urbackupserver/www2/src/features/backups/BackupContentTable.tsx
@@ -26,16 +26,6 @@ import { makeBackupsBreadcrumbs } from "./makeBackupsBreadcrumbs";
 import { TableWrapper } from "../../components/TableWrapper";
 
 const useStyles = makeStyles({
-  cell: {
-    alignItems: "unset",
-  },
-  link: {
-    color: "inherit",
-    textDecoration: "none",
-    display: "flex",
-    alignItems: "center",
-    width: "100%",
-  },
   heading: {
     display: "flex",
     gap: tokens.spacingHorizontalM,
@@ -233,7 +223,6 @@ export function BackupContentTable() {
                       group: ["actions"],
                       none: noneColumns,
                     })}
-                    className={isInteractive ? "" : classes.cell}
                     style={getNarrowColumnStyles(columnId)}
                   >
                     {isInteractive ? (
@@ -264,7 +253,6 @@ export function BackupContentTable() {
                             );
                           }
                         }}
-                        className={classes.link}
                       >
                         {renderCell(item)}
                       </a>

--- a/urbackupserver/www2/src/features/backups/BackupsError.tsx
+++ b/urbackupserver/www2/src/features/backups/BackupsError.tsx
@@ -1,0 +1,33 @@
+import { useRouteError } from "react-router-dom";
+import { BackupsAccessDeniedError } from "../../api/urbackupserver";
+import { Link } from "@fluentui/react-components";
+
+export default function BackupErrorPage() {
+  const error = useRouteError();
+
+  if (error instanceof BackupsAccessDeniedError) {
+    return (
+      <article className="flow">
+        <h1>Backups Access Denied</h1>
+        <p>
+          <i>{error.statusText || error.message}</i>
+        </p>
+        <p>
+          Return to <Link href="/#/backups">Backups</Link>.
+        </p>
+      </article>
+    );
+  }
+
+  return (
+    <article className="flow">
+      <h1>Page not found</h1>
+      <p>
+        <i>{error.statusText || error.message}</i>
+      </p>
+      <p>
+        Return to <Link href="/#/backups">Backups</Link>.
+      </p>
+    </article>
+  );
+}

--- a/urbackupserver/www2/src/features/backups/BackupsTable.tsx
+++ b/urbackupserver/www2/src/features/backups/BackupsTable.tsx
@@ -43,13 +43,10 @@ export const columns: TableColumnDefinition<BackupsClient>[] = [
   }),
 ];
 
-const REFETCH_INTERVAL = 5000;
-
 export function BackupsTable() {
   const backupClientsResult = useSuspenseQuery({
     queryKey: ["backups"],
     queryFn: () => urbackupServer.getBackupsClients(),
-    refetchInterval: REFETCH_INTERVAL,
   });
 
   const data = backupClientsResult.data!.clients;

--- a/urbackupserver/www2/src/features/backups/BackupsTable.tsx
+++ b/urbackupserver/www2/src/features/backups/BackupsTable.tsx
@@ -55,7 +55,7 @@ export function BackupsTable() {
   const data = backupClientsResult.data!.clients;
 
   if (data.length === 0) {
-    return <span>No activities</span>;
+    return <span>No clients</span>;
   }
 
   return (

--- a/urbackupserver/www2/src/features/backups/BackupsTable.tsx
+++ b/urbackupserver/www2/src/features/backups/BackupsTable.tsx
@@ -1,0 +1,109 @@
+import {
+  DataGrid,
+  DataGridHeader,
+  DataGridRow,
+  DataGridHeaderCell,
+  DataGridBody,
+  DataGridCell,
+  TableCellLayout,
+  TableColumnDefinition,
+  createTableColumn,
+  makeStyles,
+} from "@fluentui/react-components";
+import { Link } from "react-router-dom";
+import { useSuspenseQuery } from "@tanstack/react-query";
+
+import type { BackupsClient } from "../../api/urbackupserver";
+import { getCellFocusMode } from "../../utils/table";
+import { formatDatetime } from "../../utils/format";
+import { urbackupServer } from "../../App";
+import { TableWrapper } from "../../components/TableWrapper";
+
+const useStyles = makeStyles({
+  cell: {
+    alignItems: "unset",
+  },
+  link: {
+    color: "inherit",
+    textDecoration: "none",
+    display: "flex",
+    alignItems: "center",
+    width: "100%",
+  },
+});
+
+export const columns: TableColumnDefinition<BackupsClient>[] = [
+  createTableColumn<BackupsClient>({
+    columnId: "name",
+    renderHeaderCell: () => {
+      return "Computer name";
+    },
+    renderCell: (item) => {
+      return <TableCellLayout>{item.name}</TableCellLayout>;
+    },
+  }),
+  createTableColumn<BackupsClient>({
+    columnId: "lastFilebackup",
+    renderHeaderCell: () => {
+      return "Last file backup";
+    },
+    renderCell: (item) => {
+      return (
+        <TableCellLayout>
+          {item.lastbackup ? formatDatetime(item.lastbackup) : "-"}
+        </TableCellLayout>
+      );
+    },
+  }),
+];
+
+const REFETCH_INTERVAL = 5000;
+
+export function BackupsTable() {
+  const backupClientsResult = useSuspenseQuery({
+    queryKey: ["backups"],
+    queryFn: () => urbackupServer.getBackupsClients(),
+    refetchInterval: REFETCH_INTERVAL,
+  });
+
+  const data = backupClientsResult.data!.clients;
+
+  const classes = useStyles();
+
+  if (data.length === 0) {
+    return <span>No activities</span>;
+  }
+
+  return (
+    <TableWrapper>
+      <h3>Backups</h3>
+      <DataGrid items={data} getRowId={(item) => item.id} columns={columns}>
+        <DataGridHeader>
+          <DataGridRow>
+            {({ renderHeaderCell }) => (
+              <DataGridHeaderCell>{renderHeaderCell()}</DataGridHeaderCell>
+            )}
+          </DataGridRow>
+        </DataGridHeader>
+        <DataGridBody<BackupsClient>>
+          {({ item }) => (
+            <DataGridRow<BackupsClient> key={item.id}>
+              {({ renderCell, columnId }) => (
+                <DataGridCell
+                  focusMode={getCellFocusMode(columnId, {
+                    none: ["name", "lastFilebackup"],
+                  })}
+                  className={classes.cell}
+                >
+                  <Link to={String(item.id)} className={classes.link}>
+                    {renderCell(item)}
+                  </Link>
+                </DataGridCell>
+              )}
+            </DataGridRow>
+          )}
+        </DataGridBody>
+      </DataGrid>
+    </TableWrapper>
+  );
+}

--- a/urbackupserver/www2/src/features/backups/BackupsTable.tsx
+++ b/urbackupserver/www2/src/features/backups/BackupsTable.tsx
@@ -8,7 +8,6 @@ import {
   TableCellLayout,
   TableColumnDefinition,
   createTableColumn,
-  makeStyles,
 } from "@fluentui/react-components";
 import { Link } from "react-router-dom";
 import { useSuspenseQuery } from "@tanstack/react-query";
@@ -18,19 +17,6 @@ import { getCellFocusMode } from "../../utils/table";
 import { formatDatetime } from "../../utils/format";
 import { urbackupServer } from "../../App";
 import { TableWrapper } from "../../components/TableWrapper";
-
-const useStyles = makeStyles({
-  cell: {
-    alignItems: "unset",
-  },
-  link: {
-    color: "inherit",
-    textDecoration: "none",
-    display: "flex",
-    alignItems: "center",
-    width: "100%",
-  },
-});
 
 export const columns: TableColumnDefinition<BackupsClient>[] = [
   createTableColumn<BackupsClient>({
@@ -68,8 +54,6 @@ export function BackupsTable() {
 
   const data = backupClientsResult.data!.clients;
 
-  const classes = useStyles();
-
   if (data.length === 0) {
     return <span>No activities</span>;
   }
@@ -93,11 +77,8 @@ export function BackupsTable() {
                   focusMode={getCellFocusMode(columnId, {
                     none: ["name", "lastFilebackup"],
                   })}
-                  className={classes.cell}
                 >
-                  <Link to={String(item.id)} className={classes.link}>
-                    {renderCell(item)}
-                  </Link>
+                  <Link to={String(item.id)}>{renderCell(item)}</Link>
                 </DataGridCell>
               )}
             </DataGridRow>

--- a/urbackupserver/www2/src/features/backups/ClientBackupActions.tsx
+++ b/urbackupserver/www2/src/features/backups/ClientBackupActions.tsx
@@ -70,9 +70,6 @@ const useStyles = makeStyles({
     display: "flex",
     gap: tokens.spacingHorizontalXS,
   },
-  stopButton: {
-    minWidth: 0,
-  },
 });
 
 export function ClientBackupActions(backup: Backup & { clientid: number }) {

--- a/urbackupserver/www2/src/features/backups/ClientBackupActions.tsx
+++ b/urbackupserver/www2/src/features/backups/ClientBackupActions.tsx
@@ -1,0 +1,133 @@
+import { tokens, Button, makeStyles } from "@fluentui/react-components";
+import {
+  Delete16Regular,
+  PresenceOffline16Regular,
+} from "@fluentui/react-icons";
+import { useMutation, useQueryClient } from "@tanstack/react-query";
+
+import type { Backup } from "../../api/urbackupserver";
+import { urbackupServer } from "../../App";
+
+function useDeleteBackupMutation() {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: ({
+      clientId,
+      backupId,
+    }: {
+      clientId: number;
+      backupId: number;
+    }) => urbackupServer.deleteBackup(clientId, backupId),
+    onSuccess: (_, variables) => {
+      return queryClient.invalidateQueries({
+        queryKey: ["backups", variables.clientId],
+      });
+    },
+  });
+}
+
+function useStopDeleteBackupMutation() {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: ({
+      clientId,
+      backupId,
+    }: {
+      clientId: number;
+      backupId: number;
+    }) => urbackupServer.stopDeleteBackup(clientId, backupId),
+    onSuccess: (_, variables) => {
+      return queryClient.invalidateQueries({
+        queryKey: ["backups", variables.clientId],
+      });
+    },
+  });
+}
+
+function useDeleteBackupNowMutation() {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: ({
+      clientId,
+      backupId,
+    }: {
+      clientId: number;
+      backupId: number;
+    }) => urbackupServer.deleteBackupNow(clientId, backupId),
+    onSuccess: (_, variables) => {
+      return queryClient.invalidateQueries({
+        queryKey: ["backups", variables.clientId],
+      });
+    },
+  });
+}
+
+const useStyles = makeStyles({
+  root: {
+    display: "flex",
+    gap: tokens.spacingHorizontalXS,
+  },
+  stopButton: {
+    minWidth: 0,
+  },
+});
+
+export function ClientBackupActions(backup: Backup & { clientid: number }) {
+  const deleteBackupMutation = useDeleteBackupMutation();
+  const stopDeleteBackupMutation = useStopDeleteBackupMutation();
+  const deleteBackupNowMutation = useDeleteBackupNowMutation();
+
+  const classes = useStyles();
+
+  if (backup.disable_delete || backup.archived) {
+    return null;
+  }
+
+  if (backup.delete_pending) {
+    return (
+      <div className={classes.root}>
+        <Button
+          icon={<PresenceOffline16Regular />}
+          onClick={() => {
+            stopDeleteBackupMutation.mutate({
+              clientId: backup.clientid,
+              backupId: backup.id,
+            });
+          }}
+        >
+          Stop Delete
+        </Button>
+        <Button
+          icon={<Delete16Regular />}
+          onClick={() => {
+            deleteBackupNowMutation.mutate({
+              clientId: backup.clientid,
+              backupId: backup.id,
+            });
+          }}
+        >
+          Delete Now
+        </Button>
+      </div>
+    );
+  }
+
+  return (
+    <div className={classes.root}>
+      <Button
+        icon={<Delete16Regular />}
+        onClick={() => {
+          deleteBackupMutation.mutate({
+            clientId: backup.clientid,
+            backupId: backup.id,
+          });
+        }}
+      >
+        Delete
+      </Button>
+    </div>
+  );
+}

--- a/urbackupserver/www2/src/features/backups/ClientBackupsTable.tsx
+++ b/urbackupserver/www2/src/features/backups/ClientBackupsTable.tsx
@@ -1,0 +1,240 @@
+import {
+  DataGrid,
+  DataGridHeader,
+  DataGridRow,
+  DataGridHeaderCell,
+  DataGridBody,
+  DataGridCell,
+  TableCellLayout,
+  TableColumnDefinition,
+  createTableColumn,
+  makeStyles,
+  Badge,
+  tokens,
+  PresenceBadge,
+  TableColumnId,
+} from "@fluentui/react-components";
+import { Link, useParams } from "react-router-dom";
+import { useSuspenseQuery } from "@tanstack/react-query";
+
+import type { Backup } from "../../api/urbackupserver";
+import { getCellFocusMode } from "../../utils/table";
+import { format_size, formatDatetime } from "../../utils/format";
+import { urbackupServer } from "../../App";
+import { ClientBackupActions } from "./ClientBackupActions";
+import { ArchiveCheckbox } from "./ArchiveCheckbox";
+import { Breadcrumbs } from "../../components/Breadcrumbs";
+import { makeBackupsBreadcrumbs } from "./makeBackupsBreadcrumbs";
+import { TableWrapper } from "../../components/TableWrapper";
+
+const useStyles = makeStyles({
+  cell: {
+    alignItems: "unset",
+  },
+  link: {
+    color: "inherit",
+    textDecoration: "none",
+    display: "flex",
+    alignItems: "center",
+    width: "100%",
+  },
+  heading: {
+    // Negate the margin top and left values
+    // to keep breadcrumbs aligned to initial top-left position
+    marginInlineStart: "-7px",
+    marginBlockStart: "-7px",
+  },
+});
+
+export const columns: TableColumnDefinition<Backup>[] = [
+  createTableColumn<Backup>({
+    columnId: "backuptime",
+    renderHeaderCell: () => {
+      return "Backup time";
+    },
+    renderCell: (item) => {
+      return (
+        <TableCellLayout>{formatDatetime(item.backuptime)}</TableCellLayout>
+      );
+    },
+  }),
+  createTableColumn<Backup>({
+    columnId: "id",
+    renderHeaderCell: () => {
+      return "Backup ID";
+    },
+    renderCell: (item) => {
+      return (
+        <TableCellLayout>
+          <div
+            style={{
+              display: "flex",
+              alignItems: "center",
+              gap: tokens.spacingHorizontalS,
+            }}
+          >
+            <span>{item.id}</span>
+            {!!item.archive_timeout && (
+              <Badge color="informative">
+                Unarchives: {formatDatetime(item.archive_timeout)}
+              </Badge>
+            )}
+          </div>
+        </TableCellLayout>
+      );
+    },
+  }),
+  createTableColumn<Backup>({
+    columnId: "incremental",
+    renderHeaderCell: () => {
+      return "Incremental";
+    },
+    renderCell: (item) => {
+      const isIncremental = item.incremental !== 0;
+
+      return (
+        <TableCellLayout>
+          {isIncremental && <PresenceBadge status="available" />}
+        </TableCellLayout>
+      );
+    },
+  }),
+  createTableColumn<Backup>({
+    columnId: "size",
+    renderHeaderCell: () => {
+      return "Size";
+    },
+    renderCell: (item) => {
+      return <TableCellLayout>{format_size(item.size_bytes)}</TableCellLayout>;
+    },
+  }),
+  createTableColumn<Backup & { clientid: number }>({
+    columnId: "archived",
+    renderHeaderCell: () => {
+      return "Archived";
+    },
+    renderCell: ArchiveCheckbox,
+  }),
+  createTableColumn<Backup & { clientid: number }>({
+    columnId: "actions",
+    renderHeaderCell: () => {
+      return "Actions";
+    },
+    renderCell: ClientBackupActions,
+  }),
+];
+
+export function ClientBackupsTable() {
+  const { clientId } = useParams();
+
+  const backupsResult = useSuspenseQuery({
+    queryKey: ["backups", Number(clientId)],
+    queryFn: () => urbackupServer.getBackups(Number(clientId)),
+  });
+
+  const classes = useStyles();
+
+  const { clientname, clientid, backups } = backupsResult.data!;
+
+  const breadcrumbItems = makeBackupsBreadcrumbs({
+    clientId: Number(clientId),
+    clientName: clientname,
+  });
+
+  // Client doesn't exist
+  if (!clientname.length && !backups.length) {
+    throw new Error(`No such client with ID: ${clientId}`);
+  }
+
+  if (backups.length === 0) {
+    return (
+      <TableWrapper>
+        <div className={classes.heading}>
+          <Breadcrumbs items={breadcrumbItems} wrapper={"h3"} />
+        </div>
+        <p>
+          No Backup created for <strong>{clientname}</strong> yet.
+        </p>
+      </TableWrapper>
+    );
+  }
+
+  return (
+    <TableWrapper>
+      <div className={classes.heading}>
+        <Breadcrumbs items={breadcrumbItems} wrapper={"h3"} />
+      </div>
+      <DataGrid items={backups} getRowId={(item) => item.id} columns={columns}>
+        <DataGridHeader>
+          <DataGridRow>
+            {({ renderHeaderCell, columnId }) => (
+              <DataGridHeaderCell style={getNarrowColumnStyles(columnId)}>
+                {renderHeaderCell()}
+              </DataGridHeaderCell>
+            )}
+          </DataGridRow>
+        </DataGridHeader>
+        <DataGridBody<Backup>>
+          {({ item }) => (
+            <DataGridRow<Backup> key={item.id}>
+              {({ renderCell, columnId }) => {
+                const noneColumns = [
+                  "backuptime",
+                  "id",
+                  "incremental",
+                  "size",
+                  "archived",
+                  "actions",
+                ];
+                const isInteractive = ["archived", "actions"].includes(
+                  String(columnId),
+                );
+
+                return (
+                  <DataGridCell
+                    focusMode={getCellFocusMode(columnId, {
+                      group: ["actions"],
+                      none: noneColumns,
+                    })}
+                    className={isInteractive ? "" : classes.cell}
+                    style={getNarrowColumnStyles(columnId)}
+                  >
+                    {!isInteractive && (
+                      <Link to={String(item.id)} className={classes.link}>
+                        {renderCell(item)}
+                      </Link>
+                    )}
+                    {isInteractive && renderCell({ ...item, clientid })}
+                  </DataGridCell>
+                );
+              }}
+            </DataGridRow>
+          )}
+        </DataGridBody>
+      </DataGrid>
+    </TableWrapper>
+  );
+}
+
+const narrowColumnIds = ["id", "incremental", "size"];
+
+/**
+ * Style some columns to take up less space.
+ */
+function getNarrowColumnStyles(columnId: TableColumnId) {
+  const stringId = columnId.toString();
+
+  const flexGrow = narrowColumnIds.includes(stringId) ? "0" : "1";
+
+  if (["actions"].includes(stringId)) {
+    return {
+      flexGrow,
+      flexBasis: "18ch",
+    };
+  }
+
+  return {
+    flexGrow,
+    flexBasis: narrowColumnIds.includes(stringId) ? "14ch" : "0",
+  };
+}

--- a/urbackupserver/www2/src/features/backups/ClientBackupsTable.tsx
+++ b/urbackupserver/www2/src/features/backups/ClientBackupsTable.tsx
@@ -28,16 +28,6 @@ import { makeBackupsBreadcrumbs } from "./makeBackupsBreadcrumbs";
 import { TableWrapper } from "../../components/TableWrapper";
 
 const useStyles = makeStyles({
-  cell: {
-    alignItems: "unset",
-  },
-  link: {
-    color: "inherit",
-    textDecoration: "none",
-    display: "flex",
-    alignItems: "center",
-    width: "100%",
-  },
   heading: {
     // Negate the margin top and left values
     // to keep breadcrumbs aligned to initial top-left position
@@ -196,13 +186,10 @@ export function ClientBackupsTable() {
                       group: ["actions"],
                       none: noneColumns,
                     })}
-                    className={isInteractive ? "" : classes.cell}
                     style={getNarrowColumnStyles(columnId)}
                   >
                     {!isInteractive && (
-                      <Link to={String(item.id)} className={classes.link}>
-                        {renderCell(item)}
-                      </Link>
+                      <Link to={String(item.id)}>{renderCell(item)}</Link>
                     )}
                     {isInteractive && renderCell({ ...item, clientid })}
                   </DataGridCell>

--- a/urbackupserver/www2/src/features/backups/makeBackupsBreadcrumbs.ts
+++ b/urbackupserver/www2/src/features/backups/makeBackupsBreadcrumbs.ts
@@ -19,14 +19,14 @@ export function makeBackupsBreadcrumbs({
 
   const baseBreadcrumbItems: BreadcrumbItem[] = [
     {
-      key: crypto.randomUUID(),
+      key: "backups",
       text: "Backups",
       itemProps: {
         href: backupsUrl,
       },
     },
     {
-      key: crypto.randomUUID(),
+      key: `client-${clientId}`,
       text: clientName,
       itemProps: {
         href: clientUrl,
@@ -41,7 +41,7 @@ export function makeBackupsBreadcrumbs({
   const backupUrl = `${clientUrl}/${backupId}`;
 
   const backupTimeBreadCrumb = {
-    key: crypto.randomUUID(),
+    key: `backup-${backupId}`,
     text: formatDatetime(backuptime),
     itemProps: {
       href: backupUrl,

--- a/urbackupserver/www2/src/features/backups/makeBackupsBreadcrumbs.ts
+++ b/urbackupserver/www2/src/features/backups/makeBackupsBreadcrumbs.ts
@@ -1,0 +1,77 @@
+import { BASE_HREF, BreadcrumbItem } from "../../components/Breadcrumbs";
+import { formatDatetime } from "../../utils/format";
+
+export function makeBackupsBreadcrumbs({
+  clientId,
+  clientName,
+  backupId,
+  backuptime,
+  path,
+}: {
+  clientId: number;
+  clientName: string;
+  backupId?: number;
+  backuptime?: number;
+  path?: string | null;
+}) {
+  const backupsUrl = `${BASE_HREF}/backups`;
+  const clientUrl = `${backupsUrl}/${clientId}`;
+
+  const baseBreadcrumbItems: BreadcrumbItem[] = [
+    {
+      key: crypto.randomUUID(),
+      text: "Backups",
+      itemProps: {
+        href: backupsUrl,
+      },
+    },
+    {
+      key: crypto.randomUUID(),
+      text: clientName,
+      itemProps: {
+        href: clientUrl,
+      },
+    },
+  ];
+
+  if (!backuptime) {
+    return baseBreadcrumbItems;
+  }
+
+  const backupUrl = `${clientUrl}/${backupId}`;
+
+  const backupTimeBreadCrumb = {
+    key: crypto.randomUUID(),
+    text: formatDatetime(backuptime),
+    itemProps: {
+      href: backupUrl,
+    },
+  };
+
+  baseBreadcrumbItems.push(backupTimeBreadCrumb);
+
+  if (!path) {
+    return baseBreadcrumbItems;
+  }
+
+  const breadcrumbPathItems = makePathBreadcrumbItems(backupUrl, path);
+
+  return [...baseBreadcrumbItems, ...breadcrumbPathItems];
+}
+
+function makePathBreadcrumbItems(backupUrl: string, path: string) {
+  return path
+    ?.split("/")
+    .filter(Boolean)
+    .map<BreadcrumbItem>((current, index, array) => {
+      const currentPath = array.slice(0, index + 1).join("/");
+
+      return {
+        key: crypto.randomUUID(),
+        text: current,
+        itemProps: {
+          href: `${backupUrl}?path=${currentPath}`,
+        },
+      };
+    });
+}

--- a/urbackupserver/www2/src/pages/Activities.tsx
+++ b/urbackupserver/www2/src/pages/Activities.tsx
@@ -1,20 +1,11 @@
-import { makeStyles, Spinner, tokens } from "@fluentui/react-components";
+import { Spinner } from "@fluentui/react-components";
 import { Suspense } from "react";
 import { useSuspenseQuery } from "@tanstack/react-query";
 
 import { urbackupServer } from "../App";
 import { LastActivitiesTable } from "../features/activities/LastActivitiesTable";
 import { OngoingActivitiesTable } from "../features/activities/OngoingActivitiesTable";
-
-const useStyles = makeStyles({
-  root: {
-    display: "grid",
-    gap: tokens.spacingVerticalXXXL,
-  },
-  heading: {
-    marginBlockStart: 0,
-  },
-});
+import { TableWrapper } from "../components/TableWrapper";
 
 const REFETCH_INTERVAL = 5000;
 
@@ -25,22 +16,27 @@ export const ActivitiesPage = () => {
     refetchInterval: REFETCH_INTERVAL,
   });
 
-  const classes = useStyles();
-
   const lastacts = progressResult.data!.lastacts;
   const progress = progressResult.data!.progress;
 
   return (
     <Suspense fallback={<Spinner />}>
-      <div className={classes.root}>
-        <section>
-          <h3 className={classes.heading}>Activities</h3>
-          <OngoingActivitiesTable data={progress} />
-        </section>
-        <section>
-          <h3 className={classes.heading}>Last Activities</h3>
-          <LastActivitiesTable data={lastacts} />
-        </section>
+      <div
+        className="flow"
+        style={{ "--flow-space": "4em" } as React.CSSProperties}
+      >
+        <div>
+          <TableWrapper>
+            <h3>Activities</h3>
+            <OngoingActivitiesTable data={progress} />
+          </TableWrapper>
+        </div>
+        <div>
+          <TableWrapper>
+            <h3>Last Activities</h3>
+            <LastActivitiesTable data={lastacts} />
+          </TableWrapper>
+        </div>
       </div>
     </Suspense>
   );

--- a/urbackupserver/www2/src/pages/Backups.tsx
+++ b/urbackupserver/www2/src/pages/Backups.tsx
@@ -1,0 +1,13 @@
+import { Spinner } from "@fluentui/react-components";
+import { Suspense } from "react";
+import { Outlet } from "react-router-dom";
+
+export const BackupsPage = () => {
+  return (
+    <Suspense fallback={<Spinner />}>
+      <div>
+        <Outlet />
+      </div>
+    </Suspense>
+  );
+};

--- a/urbackupserver/www2/src/pages/Status.tsx
+++ b/urbackupserver/www2/src/pages/Status.tsx
@@ -41,6 +41,7 @@ import {
 } from "../features/status";
 import { useStatusClientActions } from "../features/status/useStatusClientActions";
 import { formatDatetime } from "../utils/format";
+import { TableWrapper } from "../components/TableWrapper";
 
 // Register icons used in Pagination @fluentui/react-experiments. See https://github.com/microsoft/fluentui/wiki/Using-icons#registering-custom-icons.
 registerIcons({
@@ -127,13 +128,6 @@ const columns: TableColumnDefinition<StatusClientItem>[] = [
 ];
 
 const useStyles = makeStyles({
-  root: {
-    display: "grid",
-    gap: tokens.spacingHorizontalL,
-  },
-  heading: {
-    marginBlockStart: 0,
-  },
   topFilters: {
     display: "flex",
     gap: tokens.spacingHorizontalM,
@@ -203,35 +197,33 @@ const Status = () => {
   return (
     <>
       <Suspense fallback={<Spinner />}>
-        <div className={classes.root}>
-          <div>
-            <h3 className={classes.heading}>Status page</h3>
-            <div className={classes.topFilters}>
-              <Field label="Search" className={classes.search}>
-                <SearchBox
-                  autoComplete="off"
-                  className={classes.searchBox}
-                  onChange={(_, data) => {
-                    const search = data.value.toLowerCase();
+        <TableWrapper>
+          <h3>Status page</h3>
+          <div className={classes.topFilters}>
+            <Field label="Search" className={classes.search}>
+              <SearchBox
+                autoComplete="off"
+                className={classes.searchBox}
+                onChange={(_, data) => {
+                  const search = data.value.toLowerCase();
 
-                    setSearch(search);
-                  }}
-                />
-              </Field>
-              <label className={classes.pageSize}>
-                Show
-                <Select
-                  id="page-size"
-                  defaultValue={pageSize}
-                  onChange={(_, data) => setPageSize(+data.value)}
-                >
-                  {PAGE_SIZES.map((size, id) => (
-                    <option key={id}>{size}</option>
-                  ))}
-                </Select>
-                entries
-              </label>
-            </div>
+                  setSearch(search);
+                }}
+              />
+            </Field>
+            <label className={classes.pageSize}>
+              Show
+              <Select
+                id="page-size"
+                defaultValue={pageSize}
+                onChange={(_, data) => setPageSize(+data.value)}
+              >
+                {PAGE_SIZES.map((size, id) => (
+                  <option key={id}>{size}</option>
+                ))}
+              </Select>
+              entries
+            </label>
           </div>
           {pageData.length === 0 ? null : (
             <>
@@ -329,7 +321,7 @@ const Status = () => {
               </div>
             </>
           )}
-        </div>
+        </TableWrapper>
       </Suspense>
     </>
   );

--- a/urbackupserver/www2/src/utils/table.ts
+++ b/urbackupserver/www2/src/utils/table.ts
@@ -1,0 +1,26 @@
+import {
+  TableColumnId,
+  DataGridCellFocusMode,
+} from "@fluentui/react-components";
+
+export const getCellFocusMode = (
+  columnId: TableColumnId,
+  options: {
+    group?: string[];
+    none?: string[];
+  } = {
+    group: ["actions"],
+    none: [],
+  },
+): DataGridCellFocusMode => {
+  const { group, none } = options;
+
+  if (group?.includes(String(columnId))) {
+    return "group";
+  }
+  if (none?.includes(String(columnId))) {
+    return "none";
+  }
+
+  return "cell";
+};


### PR DESCRIPTION
This PR adds the following features:
- Add side menu entry for backups
- Adds backups pages to first show a client list, then the backups a client has, then allow browsing files in  backup using the component 
- Add Download folder as ZIP button on the bottom for folders
- Add list and if required restore buttons for folders and files (do nothing yet)
- Download the file when clicking on a file via setting location.href to downloadFileURL
- Show archived backups as archived. If they have an archive timeout show that as well
- Have buttons to archive, delete, unarchive a backup using the archiveBackup, unarchiveBackup and deleteBackup functions
- Show backups that are pending delete with a stop delete button (calling stopDeleteBackup)
- Show delete now button calling deleteBackupNow

## Screenshots
### Backups page
![Screenshot from 2024-12-01 19-53-11](https://github.com/user-attachments/assets/fa80a0a8-6aaf-493e-94bd-fabd26c059b9)

### Client backups page
![Screenshot from 2024-12-01 19-49-58](https://github.com/user-attachments/assets/a54911eb-d820-4b12-a8a0-c7e79188767d)

#### If archive timeout exists
![Screenshot from 2024-11-27 23-33-47](https://github.com/user-attachments/assets/48330e00-aff0-4b9f-b148-55e86c8aadd5)

### Backup folder page
![Screenshot from 2024-12-01 19-51-05](https://github.com/user-attachments/assets/561c466e-b00a-45e7-913d-d7bd38f332c9)

## Note
I have added a dummy `List` button for backup folders/files. But I haven't seen `Restore` button used anywhere in the app. Please let me know how to trigger it if relevant.

This PR does not include the new features of the backups page (part of a future PR):
- Add a filter text box that filters the entries to contain the text entered (like on the status table)
- Pagination. If there are a lot of entries it should distribute them to multiple pages