### PR TITLE
Update logrotate_urbackupsrv

### DIFF
--- a/logrotate_urbackupsrv
+++ b/logrotate_urbackupsrv
@@ -5,6 +5,6 @@
 	create 640 urbackup urbackup
 	compress
 	postrotate
-		test -e /var/run/urbackupsrv.pid && kill -HUP `cat /var/run/urbackupsrv.pid` || /bin/systemctl kill -s HUP urbackup-server.service
+		(test -e /var/run/urbackupsrv.pid && kill -HUP `cat /var/run/urbackupsrv.pid`) || (/bin/systemctl kill -s HUP urbackup-server.service)
 	endscript
 }


### PR DESCRIPTION
I think those parenthesis would be needed !
See https://forums.urbackup.org/t/logrotate-script-error-under-systemd-distributions/14232/6