### PR TITLE
Fix systemd service should not be executable

### DIFF
--- a/install_client_linux.sh
+++ b/install_client_linux.sh
@@ -326,7 +326,7 @@ then
 		fi
 	fi
 	
-	install -c urbackupclientbackend.service $SYSTEMD_DIR
+	install -c -m 644 urbackupclientbackend.service $SYSTEMD_DIR
 	systemctl enable urbackupclientbackend.service
 	
 	SYSTEMD_DBUS=yes


### PR DESCRIPTION
Fixes:
systemd[1]: Configuration file /lib/systemd/system/urbackupclientbackend.service is marked executable. Please remove executable permission bits. Proceeding anyway.