### PR TITLE
Settings

### DIFF
--- a/urbackupserver/www2/package.json
+++ b/urbackupserver/www2/package.json
@@ -28,7 +28,8 @@
     "react-dom": "^18.3.1",
     "react-router-dom": "^6.23.0",
     "urbackup-server-webinterface": "link:",
-    "valtio": "^1.13.2"
+    "valtio": "^1.13.2",
+    "zod": "^3.25.0"
   },
   "devDependencies": {
     "@eslint/js": "^9.2.0",

--- a/urbackupserver/www2/pnpm-lock.yaml
+++ b/urbackupserver/www2/pnpm-lock.yaml
@@ -56,6 +56,9 @@ importers:
       valtio:
         specifier: ^1.13.2
         version: 1.13.2(@types/react@18.3.1)(react@18.3.1)
+      zod:
+        specifier: ^3.25.0
+        version: 3.25.51
     devDependencies:
       '@eslint/js':
         specifier: ^9.2.0
@@ -2916,6 +2919,9 @@ packages:
   yocto-queue@0.1.0:
     resolution: {integrity: sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==}
     engines: {node: '>=10'}
+
+  zod@3.25.51:
+    resolution: {integrity: sha512-TQSnBldh+XSGL+opiSIq0575wvDPqu09AqWe1F7JhUMKY+M91/aGlK4MhpVNO7MgYfHcVCB1ffwAUTJzllKJqg==}
 
 snapshots:
 
@@ -6475,3 +6481,5 @@ snapshots:
   yaml@1.10.2: {}
 
   yocto-queue@0.1.0: {}
+
+  zod@3.25.51: {}

--- a/urbackupserver/www2/src/App.tsx
+++ b/urbackupserver/www2/src/App.tsx
@@ -31,6 +31,9 @@ import { StatisticsPage } from "./pages/Statistics";
 import { LogsPage } from "./pages/Logs";
 import { ClientLogs } from "./features/logs/ClientLogs";
 import { ClientLog } from "./features/logs/ClientLog";
+import { SettingsPage } from "./pages/SettingsPage";
+import { SettingsNavSidebar } from "./features/settings/SettingsNavSidebar";
+import { SettingsServer } from "./features/settings/SettingsServer/SettingsServer";
 import "./css/global.css";
 
 const initialDark =
@@ -46,6 +49,7 @@ export enum Pages {
   Login = "login",
   About = "about",
   Logs = "logs",
+  Settings = "settings",
 }
 
 export const state = proxy({
@@ -181,6 +185,25 @@ export const router = createHashRouter([
       },
     ],
   },
+  {
+    path: `/${Pages.Settings}`,
+    element: <SettingsPage />,
+    loader: async () => {
+      state.pageAfterLogin = Pages.Settings;
+      await jumpToLoginPageIfNeccessary();
+      return null;
+    },
+    children: [
+      {
+        index: true,
+        element: <SettingsServer />,
+      },
+      {
+        path: "server",
+        element: <SettingsServer />,
+      },
+    ],
+  },
 ]);
 
 function getSessionFromLocalStorage(): string {
@@ -244,7 +267,14 @@ const App: React.FunctionComponent = () => {
                 >
                   {snap.loggedIn && (
                     <div className={styles.sidebar}>
-                      <NavSidebar />
+                      {snap.activePage === Pages.Settings ? (
+                        // TODO: Move sidebars into RouterProvider via common layout
+                        <Suspense fallback={<Spinner />}>
+                          <SettingsNavSidebar />
+                        </Suspense>
+                      ) : (
+                        <NavSidebar />
+                      )}
                     </div>
                   )}
                   <div

--- a/urbackupserver/www2/src/api/urbackupserver.ts
+++ b/urbackupserver/www2/src/api/urbackupserver.ts
@@ -430,6 +430,7 @@ export interface SettingsClients
   id: number; // Id of the client
   name: string; // Name of the client
   override: boolean; // At least some setting is client specific
+  groupname: string
 }
 
 export interface SettingsGroups
@@ -485,7 +486,7 @@ export interface GeneralSettings
   sa: "general"; // Request settings sub-action
   navitems: SettingsNavitems; // Navigation items
   cowraw_available: boolean; // If true the cowraw feature is available
-  settings: GeneralSettingsVals | [string: SettingState] | [string: SettingValueType]; // Settings
+  settings: GeneralSettingsVals | { [key: string]: SettingState } | { [key: string]: SettingValueType }; // Settings
   saved_ok: undefined | boolean; // If true the settings were saved successfully
 }
 
@@ -1059,16 +1060,18 @@ class UrBackupServer {
         "backup_database", // Switch if nightly backup of database should be enabled : boolean
         "global_local_speed", // Global local speed limit: speed (MBit/s)
         "global_internet_speed", // Global internet speed limit: speed (MBit/s)
-        "use_tmpfiles", // Switch if tmpfiles should be used : boolean (advanced)
-        "use_tmpfiles_images", // Switch if tmpfiles should be used for images : boolean (advanced)
         "update_stats_cachesize", // Size of the cache for statistics : integer number (MiBytes)
         "global_soft_fs_quota", // Global soft filesystem quota: size (percentage or size in bytes)
+        "server_url", // URL of the server : string/URL
+        "internet_server_bind_port", // Non-default port to bind to for internet backups : integer number (port range 1-65535)
+        // Advanced
+        "use_tmpfiles", // Switch if tmpfiles should be used : boolean (advanced)
+        "use_tmpfiles_images", // Switch if tmpfiles should be used for images : boolean (advanced)
         "use_incremental_symlinks", // Switch if incremental symlinks should be used : boolean (advanced)
         "show_server_updates", // Switch if server updates should be shown : boolean (advanced)
-        "server_url", // URL of the server : string/URL
+        // Don't add
         "internet_expect_endpoint", // Expect endpoint for internet backups : string (don't add)
-        "internet_server_bind_port" // Non-default port to bind to for internet backups : integer number (port range 1-65535)
-        ];
+        ] as const;
     }
 
     // Get list of mail server settings

--- a/urbackupserver/www2/src/components/NavSidebar.tsx
+++ b/urbackupserver/www2/src/components/NavSidebar.tsx
@@ -22,6 +22,7 @@ export const NavSidebar = () => {
       <Tab value={Pages.Backups}>Backups</Tab>
       <Tab value={Pages.Statistics}>Statistics</Tab>
       <Tab value={Pages.Logs}>Logs</Tab>
+      <Tab value={Pages.Settings}>Settings</Tab>
     </TabList>
   );
 };

--- a/urbackupserver/www2/src/components/NewTabLink.module.css
+++ b/urbackupserver/www2/src/components/NewTabLink.module.css
@@ -1,0 +1,4 @@
+.icon {
+  vertical-align: middle;
+  margin-inline-start: 0.3em;
+}

--- a/urbackupserver/www2/src/components/NewTabLink.tsx
+++ b/urbackupserver/www2/src/components/NewTabLink.tsx
@@ -1,0 +1,15 @@
+import { OpenRegular } from "@fluentui/react-icons";
+
+import styles from "./NewTabLink.module.css";
+
+export function NewTabLink(
+  props: React.AnchorHTMLAttributes<HTMLAnchorElement>,
+) {
+  return (
+    <a target="_blank" rel="noreferrer" {...props}>
+      {props.children}
+      <span className="visually-hidden"> (opens in a new tab)</span>
+      <OpenRegular className={styles.icon} />
+    </a>
+  );
+}

--- a/urbackupserver/www2/src/components/SelectClientCombobox.tsx
+++ b/urbackupserver/www2/src/components/SelectClientCombobox.tsx
@@ -11,27 +11,76 @@ export function SelectClientCombobox({
   clients,
   onSelect,
   defaultValue,
+  label,
+  placeholder,
+  showLabel = true,
+  hideAllClients,
 }: {
   clients: ClientInfo[];
   onSelect: (value?: string) => void;
   defaultValue?: ClientInfo["name"];
+  label?: string;
+  placeholder?: string;
+  showLabel?: boolean;
+  hideAllClients?: boolean;
 }) {
-  const options = [
-    {
-      children: "All clients",
-      value: "all",
-    },
-    ...clients.map((client) => ({
-      children: client.name,
-      value: String(client.id),
-    })),
-  ];
+  const { onOptionSelect, query, setQuery, comboBoxChildren } =
+    useClientCombobox(clients, onSelect, defaultValue, hideAllClients);
 
-  const comboId = useId();
+  const id = useId();
+  const labelId = useId();
+
+  return (
+    <div className="cluster" data-spacing="s">
+      {showLabel && (
+        <label htmlFor={id} id={labelId}>
+          {label ?? "Select client"}
+        </label>
+      )}
+      <Combobox
+        id={id}
+        aria-labelledby={labelId}
+        placeholder={placeholder}
+        onOptionSelect={onOptionSelect}
+        onChange={(ev) => setQuery(ev.target.value)}
+        onOpenChange={(_, data) => {
+          if (data.open) {
+            setQuery("");
+          }
+        }}
+        value={query}
+      >
+        {comboBoxChildren}
+      </Combobox>
+    </div>
+  );
+}
+
+function useClientCombobox(
+  clients: ClientInfo[],
+  onSelect: (value?: string) => void,
+  defaultValue?: ClientInfo["name"],
+  hideAllClients?: boolean,
+) {
+  const clientsOptions = clients.map((client) => ({
+    children: client.name,
+    value: String(client.id),
+  }));
+
+  const options = hideAllClients
+    ? clientsOptions
+    : [
+        {
+          children: "All clients",
+          value: "all",
+        },
+        ...clientsOptions,
+      ];
 
   const [query, setQuery] = useState<ClientInfo["name"]>(
     defaultValue ?? options[0].children,
   );
+
   const comboBoxChildren = useComboboxFilter(query, options, {
     optionToText: (d) => d.children,
     noOptionsMessage: `No results matched "${query}"`,
@@ -51,22 +100,10 @@ export function SelectClientCombobox({
     setQuery(selectedClient.name);
   };
 
-  return (
-    <div className="cluster" data-spacing="s">
-      <label id={comboId}>Select client</label>
-      <Combobox
-        aria-labelledby={comboId}
-        onOptionSelect={onOptionSelect}
-        onChange={(ev) => setQuery(ev.target.value)}
-        onOpenChange={(_, data) => {
-          if (data.open) {
-            setQuery("");
-          }
-        }}
-        value={query}
-      >
-        {comboBoxChildren}
-      </Combobox>
-    </div>
-  );
+  return {
+    query,
+    setQuery,
+    onOptionSelect,
+    comboBoxChildren,
+  };
 }

--- a/urbackupserver/www2/src/components/StackStyles.tsx
+++ b/urbackupserver/www2/src/components/StackStyles.tsx
@@ -46,16 +46,19 @@ export const useStackStyles = makeStyles({
     flex: 1,
   },
   content: {
-    padding: "10pt",
+    paddingInline: "10pt",
+    paddingBlock: "10pt 40pt",
     maxWidth: "1200px",
     marginInline: "auto",
   },
   sidebar: {
+    width: "22ch",
     borderRight: "1px solid",
     padding: "10pt",
     position: "sticky",
     top: 0,
     left: 0,
     maxHeight: "100vh",
+    overflowY: "auto",
   },
 });

--- a/urbackupserver/www2/src/css/global.css
+++ b/urbackupserver/www2/src/css/global.css
@@ -101,6 +101,22 @@
   }
 }
 
+@layer utilities {
+  .visually-hidden {
+    position: absolute;
+    width: 1px;
+    height: 1px;
+    margin: -1px;
+    padding: 0;
+    overflow: hidden;
+    clip: rect(0 0 0 0);
+    clip-path: inset(50%);
+    border: 0;
+    white-space: nowrap;
+    user-select: none;
+  }
+}
+
 /* Table */
 .table-wrapper {
   --flow-space: 1.5em;

--- a/urbackupserver/www2/src/features/settings/Fields/CheckboxField.tsx
+++ b/urbackupserver/www2/src/features/settings/Fields/CheckboxField.tsx
@@ -1,0 +1,35 @@
+import { Field, Checkbox } from "@fluentui/react-components";
+import { useState } from "react";
+
+export function CheckboxField({
+  label,
+  id,
+  name,
+  defaultChecked,
+  onChange,
+}: {
+  label: string;
+  id: string;
+  name: string;
+  defaultChecked: boolean;
+  onChange: (value: boolean) => void;
+}) {
+  const [value, setValue] = useState(defaultChecked);
+
+  return (
+    <Field>
+      <Checkbox
+        id={id}
+        label={label}
+        name={name}
+        checked={value}
+        onChange={(_, data) => {
+          const newValue = Boolean(data.checked);
+
+          setValue(newValue);
+          onChange(newValue);
+        }}
+      />
+    </Field>
+  );
+}

--- a/urbackupserver/www2/src/features/settings/Fields/TextField.module.css
+++ b/urbackupserver/www2/src/features/settings/Fields/TextField.module.css
@@ -1,0 +1,38 @@
+.field:has(.reset-input) {
+  grid-template-columns: auto 34ch;
+  align-items: center;
+}
+
+.field [role="alert"] {
+  grid-column: 1 / -1;
+}
+
+.reset-input {
+  display: flex;
+  align-self: baseline;
+  align-items: center;
+  justify-content: end;
+  width: 100%;
+  gap: var(--spacingXS);
+}
+
+.reset-input > [data-hidden="true"] {
+  visibility: hidden;
+}
+
+.reset-input > :has(input) {
+  flex: 1;
+}
+
+.reset-input :has([data-field-width="33%"]) {
+  max-width: 33%;
+}
+
+.reset-input :has([data-field-width="50%"]) {
+  max-width: 50%;
+}
+
+.field-description {
+  color: var(--colorNeutralForeground2);
+  margin-block-start: var(--spacingXS);
+}

--- a/urbackupserver/www2/src/features/settings/Fields/TextField.tsx
+++ b/urbackupserver/www2/src/features/settings/Fields/TextField.tsx
@@ -1,0 +1,113 @@
+import {
+  Body1,
+  Button,
+  Field,
+  Input,
+  Label,
+  LabelProps,
+  type InputProps,
+} from "@fluentui/react-components";
+import { ArrowResetRegular } from "@fluentui/react-icons";
+import { useState } from "react";
+import type { ZodMiniType } from "zod/v4-mini";
+
+import styles from "./TextField.module.css";
+
+export function TextField({
+  schema,
+  label,
+  description,
+  hint,
+  name,
+  defaultValue,
+  type,
+  onChange,
+  inputProps,
+}: {
+  schema: ZodMiniType;
+  label: string;
+  description: React.ReactNode;
+  hint?: string;
+  name: string;
+  defaultValue: string;
+  type: InputProps["type"];
+  onChange: (value: unknown) => void;
+  inputProps?: InputProps;
+}) {
+  const [validationMessage, setValidationMessage] = useState("");
+  const [value, setValue] = useState(defaultValue);
+
+  const showHint = !validationMessage;
+
+  const handleChange = (newValue: string) => {
+    const parsed = schema.safeParse(newValue);
+
+    if (parsed.success) {
+      const parsedValue = parsed.data;
+      onChange(parsedValue);
+    }
+  };
+
+  return (
+    <Field
+      hint={showHint ? hint : undefined}
+      label={{
+        children: (_: unknown, slotProps: LabelProps) => (
+          <div>
+            <Label {...slotProps}>{label}</Label>
+            {description && (
+              <p className={styles["field-description"]}>
+                <Body1>{description}</Body1>
+              </p>
+            )}
+          </div>
+        ),
+      }}
+      {...(validationMessage && {
+        validationState: "error",
+        validationMessage,
+      })}
+      orientation="horizontal"
+      className={styles.field}
+    >
+      <div className={styles["reset-input"]}>
+        <Button
+          appearance="subtle"
+          icon={<ArrowResetRegular />}
+          data-hidden={value == defaultValue}
+          onClick={() => {
+            const value = String(defaultValue);
+
+            setValue(value);
+            setValidationMessage("");
+
+            handleChange(value);
+          }}
+        >
+          Reset
+        </Button>
+        <Input
+          name={name}
+          type={type}
+          value={value}
+          {...inputProps}
+          onBlur={(e) => {
+            const { target } = e;
+
+            const fieldError = schema.safeParse(target.value).error;
+
+            if (fieldError) {
+              return setValidationMessage(fieldError.issues[0].message);
+            }
+
+            setValidationMessage("");
+          }}
+          onChange={(_, { value }) => {
+            setValue(value);
+            handleChange(value);
+          }}
+        />
+      </div>
+    </Field>
+  );
+}

--- a/urbackupserver/www2/src/features/settings/SettingsNavSidebar.module.css
+++ b/urbackupserver/www2/src/features/settings/SettingsNavSidebar.module.css
@@ -1,0 +1,8 @@
+.settings-tab div:has([type="text"]) {
+  margin-block-start: var(--spacingXS);
+  min-width: auto;
+}
+
+.settings-tab [type="text"] {
+  min-width: 100%;
+}

--- a/urbackupserver/www2/src/features/settings/SettingsNavSidebar.tsx
+++ b/urbackupserver/www2/src/features/settings/SettingsNavSidebar.tsx
@@ -1,0 +1,81 @@
+import { Fragment } from "react";
+import {
+  Link,
+  Tab as FUITab,
+  TabList,
+  Body1,
+} from "@fluentui/react-components";
+
+import { router } from "../../App";
+import { type Tab, useSettingsTabs } from "./useSettingsTabs";
+import styles from "./SettingsNavSidebar.module.css";
+
+export const SettingsNavSidebar = () => {
+  const { settingsTabs, selectedTab, onTabSelect } = useSettingsTabs();
+
+  return (
+    <div className={styles["settings-tab"]}>
+      <Link
+        onMouseDown={async () => {
+          await router.navigate("/");
+        }}
+      >
+        Back to app
+      </Link>
+
+      <div
+        style={{
+          marginBlockStart: "var(--spacingL)",
+        }}
+      >
+        <TabList selectedValue={selectedTab} vertical onTabSelect={onTabSelect}>
+          <SettingsTabs tabs={settingsTabs} />
+        </TabList>
+      </div>
+    </div>
+  );
+};
+
+function SettingsTabs({
+  tabs,
+  baseValue = "",
+}: {
+  tabs: Tab[];
+  baseValue?: string;
+}) {
+  return (
+    <>
+      {tabs.map((st, i) => {
+        if (st.children) {
+          return (
+            <Fragment key={i}>
+              <h4
+                style={{
+                  color: "var(--colorNeutralForeground3)",
+                  marginBlockStart: "var(--spacingXL)",
+                  marginBlockEnd: "var(--spacingS)",
+                }}
+              >
+                {st.title}
+              </h4>
+              <SettingsTabs tabs={st.children} baseValue={`${st.value}/`} />
+              {st?.afterChildren && st.afterChildren}
+            </Fragment>
+          );
+        }
+
+        return (
+          <FUITab key={st.value} value={`${baseValue}${st.value}`}>
+            <Body1
+              style={{
+                color: "var(--colorNeutralForeground1)",
+              }}
+            >
+              {st.title}
+            </Body1>
+          </FUITab>
+        );
+      })}
+    </>
+  );
+}

--- a/urbackupserver/www2/src/features/settings/SettingsServer/SettingsServer.module.css
+++ b/urbackupserver/www2/src/features/settings/SettingsServer/SettingsServer.module.css
@@ -1,0 +1,35 @@
+.container {
+  --border-color: var(--colorNeutralStroke2);
+  --flow-space: 2em;
+
+  width: 74ch;
+  margin: 0 auto;
+  padding-block-end: --spacing;
+}
+
+.card {
+  display: "flex";
+  flex-direction: "column";
+  background: var(--colorNeutralCardBackground);
+  padding: var(--spacingL);
+  border-radius: var(--borderRadiusLarge);
+  border-width: 1px;
+  border-style: solid;
+  border-color: var(--border-color);
+}
+
+.form > :has(label) {
+  padding-block: 0.5em;
+}
+
+.form > :first-child:has(label) {
+  padding-block-start: 0em;
+}
+
+.form > :last-child:has(label) {
+  padding-block-end: 0em;
+}
+
+.form > :has(label):not(:last-of-type) {
+  border-block-end: 1px solid var(--border-color);
+}

--- a/urbackupserver/www2/src/features/settings/SettingsServer/SettingsServer.tsx
+++ b/urbackupserver/www2/src/features/settings/SettingsServer/SettingsServer.tsx
@@ -1,0 +1,143 @@
+import { useState } from "react";
+import { Button } from "@fluentui/react-components";
+import type { ZodMiniType } from "zod/v4-mini";
+
+import type {
+  GeneralSettings,
+  SettingState,
+} from "../../../api/urbackupserver";
+import styles from "./SettingsServer.module.css";
+import { CheckboxField } from "../Fields/CheckboxField";
+import {
+  AdvancedServerFieldNames,
+  advancedServerFields,
+  advancedServerFormSchema,
+  Field,
+  ServerFieldNames,
+  serverFields,
+  serverFormSchema,
+} from "./serverForm";
+import { TextField } from "../Fields/TextField";
+import { useSettings } from "../useSettings";
+
+export function SettingsServer() {
+  const { settings, updateSettings } = useSettings();
+
+  const [initialFormState] = useState(() =>
+    getInitialFormState([...serverFields, ...advancedServerFields], settings),
+  );
+
+  const [showAdvancedSettings, setShowAdvancedSettings] = useState(false);
+
+  if (!settings) {
+    return null;
+  }
+
+  return (
+    <div className={`${styles.container} flow`}>
+      <h1>Server</h1>
+      <section className={styles.card}>
+        <FormSection
+          fields={serverFields}
+          schema={serverFormSchema}
+          initialFormState={initialFormState}
+          updateSettings={updateSettings}
+        />
+      </section>
+
+      {!showAdvancedSettings && (
+        <div>
+          <Button onClick={() => setShowAdvancedSettings(true)}>
+            Show advanced settings
+          </Button>
+        </div>
+      )}
+
+      {showAdvancedSettings && (
+        <>
+          <h2>Advanced</h2>
+          <section className={styles.card}>
+            <FormSection
+              fields={advancedServerFields}
+              schema={advancedServerFormSchema}
+              initialFormState={initialFormState}
+              updateSettings={updateSettings}
+            />
+          </section>
+        </>
+      )}
+    </div>
+  );
+}
+
+function FormSection<T extends string>({
+  fields,
+  schema,
+  initialFormState,
+  updateSettings,
+}: {
+  fields: Field<T>[];
+  schema: Record<string, ZodMiniType>;
+  initialFormState: Record<string, SettingState["value"]>;
+  updateSettings: (
+    settings: Omit<GeneralSettings["settings"], "can_edit_scripts">,
+  ) => void;
+}) {
+  return (
+    <form className={`${styles.form}`}>
+      {fields.map((f) => {
+        const initialValue = initialFormState[f.name];
+
+        if (f.type === "checkbox") {
+          return (
+            <CheckboxField
+              key={f.name}
+              id={f.name}
+              label={f.label}
+              defaultChecked={!!initialValue}
+              name={f.name}
+              onChange={(data: boolean) => {
+                updateSettings({
+                  [f.name]: data,
+                });
+              }}
+            />
+          );
+        }
+
+        const value = f.transformer?.ui(+initialValue) ?? initialValue;
+
+        return (
+          <TextField
+            key={f.name}
+            label={f.label}
+            description={f.description}
+            hint={f.hint}
+            name={f.name}
+            defaultValue={String(value)}
+            schema={schema[f.name]}
+            type={f.type}
+            onChange={(data) => {
+              const newSetting = {
+                [f.name]: f.transformer?.api(+data) ?? data,
+              };
+
+              updateSettings(newSetting);
+            }}
+            inputProps={f.inputProps}
+          />
+        );
+      })}
+    </form>
+  );
+}
+
+function getInitialFormState(
+  fields: Field<ServerFieldNames | AdvancedServerFieldNames>[],
+  settings: Record<string, SettingState["value"]>,
+) {
+  return fields.reduce(
+    (all, f) => ({ ...all, [f.name]: settings[f.name] ?? "" }),
+    {} as Record<ServerFieldNames, SettingState["value"]>,
+  );
+}

--- a/urbackupserver/www2/src/features/settings/SettingsServer/serverForm.tsx
+++ b/urbackupserver/www2/src/features/settings/SettingsServer/serverForm.tsx
@@ -1,0 +1,365 @@
+import { z, type ZodMiniType } from "zod/v4-mini";
+import { InputProps } from "@fluentui/react-components";
+
+import { NewTabLink } from "../../../components/NewTabLink";
+
+const CLEANUP_WINDOW_REGEX =
+  /^(([mon|mo|tu|tue|tues|di|wed|mi|th|thu|thur|thurs|do|fri|fr|sat|sa|sun|so|1-7]\-?[mon|mo|tu|tue|tues|di|wed|mi|th|thu|thur|thurs|do|fri|fr|sat|sa|sun|so|1-7]?\s*[,]?\s*)+\/([0-9][0-9]?:?[0-9]?[0-9]?\-[0-9][0-9]?:?[0-9]?[0-9]?\s*[,]?\s*)+\s*[;]?\s*)*$/i;
+
+export const SERVER_LABELS = {
+  backupfolder: "Backup storage path",
+  no_images: "Do not do image backups",
+  no_file_backups: "Do not do file backups",
+  autoshutdown: "Automatically shut down server",
+  download_client: "Download client from update server",
+  autoupdate_clients: "Autoupdate clients",
+  max_sim_backups: "Max simultaneous backups",
+  max_active_clients: "Max recently active clients",
+  tmpdir: "Nondefault temporary file directory",
+  cleanup_window: "Cleanup time window",
+  backup_database: "Automatically backup UrBackup database",
+  global_local_speed: "Total max backup speed for local network",
+  global_internet_speed:
+    "Total max backup speed for Internet/active connection",
+  update_stats_cachesize: "Database cache size during batch processing",
+  global_soft_fs_quota: "Global soft filesystem quota",
+  server_url: "Server URL for client file/backup access/browsing",
+  internet_server_bind_port: "Non-default UrBackup Internet protocol TCP port",
+} as const;
+
+export const ADVANCED_SERVER_LABELS = {
+  use_tmpfiles: "Temporary files as file backup buffer",
+  use_tmpfiles_images: "Temporary files as image backup buffer",
+  use_incremental_symlinks: "Use symlinks during incremental file backups",
+  show_server_updates: "Show when a new server version is available",
+} as const;
+
+export type ServerFieldNames = keyof typeof SERVER_LABELS;
+export type AdvancedServerFieldNames = keyof typeof ADVANCED_SERVER_LABELS;
+
+function getLabelFromName(name: string, labels: Record<string, string>) {
+  if (!Object.keys(labels).includes(name)) {
+    return "";
+  }
+
+  return labels[name as keyof typeof labels];
+}
+
+const VALIDATION_MESSAGES = {
+  required: (label: string) =>
+    `Please enter a value for ${label.toLowerCase()}`,
+  numeric: (label: string) =>
+    `Please enter a numeric value for ${label.toLowerCase()}`,
+  regex: (label: string) => `The format for ${label.toLowerCase()} is invalid`,
+} as const;
+
+const FORM_MESSAGES = {
+  backupfolder: VALIDATION_MESSAGES.required(SERVER_LABELS["backupfolder"]),
+  tmpdir: VALIDATION_MESSAGES.required(SERVER_LABELS["tmpdir"]),
+  server_url:
+    "The server URL should be a URL starting with http:// or https://",
+  max_sim_backups: VALIDATION_MESSAGES.numeric(
+    SERVER_LABELS["max_sim_backups"],
+  ),
+  max_active_clients: VALIDATION_MESSAGES.numeric(
+    SERVER_LABELS["max_active_clients"],
+  ),
+  cleanup_window: VALIDATION_MESSAGES.regex(SERVER_LABELS["cleanup_window"]),
+  global_local_speed: VALIDATION_MESSAGES.numeric(
+    SERVER_LABELS["global_local_speed"],
+  ),
+  global_internet_speed: VALIDATION_MESSAGES.numeric(
+    SERVER_LABELS["global_internet_speed"],
+  ),
+  update_stats_cachesize: VALIDATION_MESSAGES.numeric(
+    SERVER_LABELS["update_stats_cachesize"],
+  ),
+  internet_server_bind_port:
+    "The internet server bind port must have port range from 1-65535",
+} as const;
+
+const requiredStringValidation = (message?: string) =>
+  z.string().check(z.minLength(1, message));
+
+const stringToInt = (message?: string, minLength = 0) =>
+  z.pipe(
+    z.string().check(z.minLength(minLength, message)),
+    z.transform(Number),
+  );
+
+const integerValidation = (
+  message?: string,
+  options?: { required?: boolean },
+) =>
+  stringToInt(message, options?.required ? 1 : 0).check(
+    z.int(message),
+    z.nonnegative(message),
+  );
+
+export const serverFormSchema: Record<ServerFieldNames, ZodMiniType> = {
+  backupfolder: requiredStringValidation(FORM_MESSAGES["backupfolder"]),
+  max_sim_backups: integerValidation(FORM_MESSAGES["max_sim_backups"], {
+    required: true,
+  }),
+  max_active_clients: integerValidation(
+    FORM_MESSAGES["max_active_clients"],
+    {},
+  ),
+  tmpdir: z.string(FORM_MESSAGES["tmpdir"]),
+  cleanup_window: z
+    .string()
+    .check(z.regex(CLEANUP_WINDOW_REGEX, FORM_MESSAGES["cleanup_window"])),
+  global_local_speed: integerValidation(FORM_MESSAGES["global_local_speed"]),
+  global_internet_speed: integerValidation(
+    FORM_MESSAGES["global_internet_speed"],
+  ),
+  update_stats_cachesize: integerValidation(
+    FORM_MESSAGES["update_stats_cachesize"],
+  ),
+  global_soft_fs_quota: z.string(),
+  server_url: z.union(
+    [
+      z.literal(""),
+      z.url({
+        protocol: /^https?$/,
+        hostname: z.regexes.domain,
+      }),
+    ],
+    FORM_MESSAGES["server_url"],
+  ),
+  internet_server_bind_port: z.union(
+    [z.literal(""), z.coerce.number().check(z.minimum(1), z.maximum(65535))],
+    FORM_MESSAGES["internet_server_bind_port"],
+  ),
+  no_images: z.boolean(),
+  no_file_backups: z.boolean(),
+  autoshutdown: z.boolean(),
+  download_client: z.boolean(),
+  autoupdate_clients: z.boolean(),
+  backup_database: z.boolean(),
+};
+
+export const advancedServerFormSchema: Record<
+  AdvancedServerFieldNames,
+  ZodMiniType
+> = {
+  use_tmpfiles: z.boolean(),
+  use_tmpfiles_images: z.boolean(),
+  use_incremental_symlinks: z.boolean(),
+  show_server_updates: z.boolean(),
+};
+
+interface BaseField<Names> {
+  name: Names;
+  type: "checkbox" | "number" | "text";
+  validation?: (options?: { label?: string }) => z.ZodMiniType;
+  description?: React.ReactNode;
+  hint?: string;
+  inputProps?: InputProps & {
+    "data-field-width": string;
+  };
+  transformer?: {
+    ui: (v: number) => number | string;
+    api: (v: number) => number | string;
+  };
+}
+
+export interface Field<Name> extends BaseField<Name> {
+  label: string;
+}
+
+const DATA_RATE_UNIT_LOCAL = "Mbit/s";
+const DATA_RATE_UNIT_INTERNET = "kbit/s";
+
+const baseServerFields: BaseField<ServerFieldNames>[] = [
+  {
+    name: "backupfolder",
+    type: "text",
+  },
+  {
+    name: "no_images",
+    type: "checkbox",
+  },
+  {
+    name: "no_file_backups",
+    type: "checkbox",
+  },
+  {
+    name: "autoshutdown",
+    type: "checkbox",
+  },
+  {
+    name: "download_client",
+    type: "checkbox",
+  },
+  {
+    name: "autoupdate_clients",
+    type: "checkbox",
+  },
+  {
+    name: "max_sim_backups",
+    type: "number",
+    inputProps: {
+      "data-field-width": "33%",
+    },
+  },
+  {
+    name: "max_active_clients",
+    type: "number",
+    inputProps: {
+      "data-field-width": "33%",
+    },
+  },
+  {
+    name: "tmpdir",
+    type: "text",
+  },
+  {
+    name: "cleanup_window",
+    type: "text",
+    description: (
+      <>
+        Pick a time when old backups are cleaned. e.g. 1-7/3-4 means clean-up
+        will start on each day (1-Monday - 7-Sunday) between 3 am and 4 am.{" "}
+        <NewTabLink href="http://127.0.0.1:55414/help.htm#cleanup_window">
+          How to define a clean-up window
+        </NewTabLink>
+      </>
+    ),
+  },
+  {
+    name: "backup_database",
+    type: "checkbox",
+  },
+  {
+    name: "global_local_speed",
+    type: "number",
+    inputProps: {
+      contentAfter: DATA_RATE_UNIT_LOCAL,
+      "data-field-width": "50%",
+      placeholder: "-",
+    },
+    transformer: {
+      ui: (v: number) => (v === 0 ? "-" : bytesPStoBitsPS(v, "M")),
+      api: (v: number) => bitsPStoBytesPS(v, "M"),
+    },
+  },
+  {
+    name: "global_internet_speed",
+    type: "number",
+    inputProps: {
+      contentAfter: DATA_RATE_UNIT_INTERNET,
+      "data-field-width": "50%",
+      placeholder: "-",
+    },
+    transformer: {
+      ui: (v: number) => (v === 0 ? "-" : bytesPStoBitsPS(v, "k")),
+      api: (v: number) => bitsPStoBytesPS(v, "k"),
+    },
+  },
+  {
+    name: "update_stats_cachesize",
+    type: "number",
+    inputProps: {
+      contentAfter: "MB",
+      "data-field-width": "50%",
+    },
+    transformer: {
+      ui: (v: number) => v / 1024,
+      api: (v: number) => v * 1024,
+    },
+  },
+  {
+    name: "global_soft_fs_quota",
+    type: "text",
+    description: (
+      <>
+        Set how much of the max storage space to use before old backups are
+        cleaned up. e.g. "95%", "50G".{" "}
+        <NewTabLink href="http://127.0.0.1:55414/help.htm#global_soft_fs_quota">
+          Global soft filesystem quota
+        </NewTabLink>
+      </>
+    ),
+    inputProps: {
+      "data-field-width": "33%",
+    },
+  },
+  {
+    name: "server_url",
+    type: "text",
+  },
+  {
+    name: "internet_server_bind_port",
+    type: "number",
+    inputProps: {
+      "data-field-width": "33%",
+    },
+    hint: "Port range 1-65535",
+  },
+];
+
+const baseAdvancedServerFields: BaseField<AdvancedServerFieldNames>[] = [
+  {
+    name: "use_tmpfiles",
+    type: "checkbox",
+  },
+  {
+    name: "use_tmpfiles_images",
+    type: "checkbox",
+  },
+  {
+    name: "use_incremental_symlinks",
+    type: "checkbox",
+  },
+  {
+    name: "show_server_updates",
+    type: "checkbox",
+  },
+];
+
+export const serverFields = baseServerFields.map<Field<ServerFieldNames>>(
+  (f) => ({
+    ...f,
+    label: getLabelFromName(f.name, SERVER_LABELS),
+  }),
+);
+
+export const advancedServerFields = baseAdvancedServerFields.map<
+  Field<AdvancedServerFieldNames>
+>((f) => ({
+  ...f,
+  label: getLabelFromName(f.name, ADVANCED_SERVER_LABELS),
+}));
+
+// TODO: "Megabit per second (Mbit/s)" is in powers of 1000 instead of 1024, like in original code.
+// Is it okay to fix the conversion or was the UI meant to use `Mibit/s` instead?
+const RATE_POWER = 1024;
+
+function bitsPStoBytesPS(value: number, suffix?: "M" | "k") {
+  const newValue = value * RATE_POWER;
+
+  if (suffix === "k") {
+    return bitsPStoBytesPS(newValue);
+  }
+
+  if (suffix === "M") {
+    return bitsPStoBytesPS(newValue, "k");
+  }
+
+  return value / 8;
+}
+
+function bytesPStoBitsPS(value: number, suffix?: "M" | "k") {
+  const newValue = value / RATE_POWER;
+
+  if (suffix === "k") {
+    return bytesPStoBitsPS(newValue);
+  }
+
+  if (suffix === "M") {
+    return bytesPStoBitsPS(newValue, "k");
+  }
+
+  return value * 8;
+}

--- a/urbackupserver/www2/src/features/settings/useSettings.ts
+++ b/urbackupserver/www2/src/features/settings/useSettings.ts
@@ -1,0 +1,40 @@
+import {
+  useMutation,
+  useQueryClient,
+  useSuspenseQuery,
+} from "@tanstack/react-query";
+
+import { urbackupServer } from "../../App";
+import type { GeneralSettings, SettingState } from "../../api/urbackupserver";
+
+const QUERY_KEY = ["settings"];
+
+export function useSettings() {
+  const queryClient = useQueryClient();
+
+  const {
+    data: { settings, navitems },
+  } = useSuspenseQuery({
+    queryKey: QUERY_KEY,
+    queryFn: urbackupServer.getGeneralSettings,
+  });
+
+  const mutation = useMutation({
+    mutationFn: urbackupServer.saveGeneralSettings,
+    onSuccess: () => {
+      return queryClient.invalidateQueries({
+        queryKey: QUERY_KEY,
+      });
+    },
+  });
+
+  const updateSettings = (settings: GeneralSettings["settings"]) => {
+    mutation.mutate({ settings });
+  };
+
+  return {
+    settings: settings as Record<string, SettingState["value"]>,
+    navitems,
+    updateSettings,
+  };
+}

--- a/urbackupserver/www2/src/features/settings/useSettingsTabs.tsx
+++ b/urbackupserver/www2/src/features/settings/useSettingsTabs.tsx
@@ -1,0 +1,181 @@
+import { useState } from "react";
+import {
+  SelectTabEvent,
+  SelectTabData,
+  Caption1,
+  Button,
+} from "@fluentui/react-components";
+import { Add16Regular } from "@fluentui/react-icons";
+
+import { router } from "../../App";
+import { useSettings } from "./useSettings";
+import { SettingsNavitems } from "../../api/urbackupserver";
+import { SelectClientCombobox } from "../../components/SelectClientCombobox";
+
+export interface Tab {
+  value: string;
+  title: React.ReactNode;
+  children?: Tab[];
+  afterChildren?: React.ReactNode;
+}
+
+const BASE_SETTINGS_URL = "/settings";
+
+export function useSettingsTabs() {
+  const { navitems } = useSettings();
+
+  const [selectedTab, setSelectedTab] = useState(() =>
+    getSelectedPage(BASE_SETTINGS_TABS),
+  );
+
+  const onTabSelect = async (_: SelectTabEvent, data: SelectTabData) => {
+    setSelectedTab(data.value as string);
+
+    const nt = `${BASE_SETTINGS_URL}/${data.value}`;
+    await router.navigate(nt);
+  };
+
+  const settingsTabs = updateSettingsTabs(BASE_SETTINGS_TABS, navitems);
+
+  return {
+    settingsTabs,
+    selectedTab,
+    onTabSelect,
+  };
+}
+
+function addGroupsToSettingsNav(
+  settingsTabs: Tab[],
+  navItems: SettingsNavitems,
+) {
+  const newNavItems = navItems.groups
+    .filter((g) => g.name.length)
+    .reduce((all, group) => {
+      return [...all, { value: group.name, title: group.name }];
+    }, [] as Tab[]);
+
+  const routes = {
+    value: "groups",
+    title: "Groups",
+    children: newNavItems,
+    afterChildren: (
+      <Button
+        appearance="subtle"
+        icon={<Add16Regular />}
+        style={{
+          justifyContent: "start",
+          paddingInlineStart: "var(--spacingXS)",
+          color: "var(--colorNeutralForeground3)",
+        }}
+      >
+        Add new group
+      </Button>
+    ),
+  };
+
+  return [...settingsTabs, routes];
+}
+
+function addClientsToSettingsNav(
+  settingsTabs: Tab[],
+  navItems: SettingsNavitems,
+) {
+  const newNavItems = navItems.clients
+    .filter((c) => c.override)
+    .reduce((all, client) => {
+      return [
+        ...all,
+        {
+          value: client.name,
+          title: client.group ? (
+            <span className="cluster">
+              {client.name} <Caption1>({client.groupname})</Caption1>
+            </span>
+          ) : (
+            client.name
+          ),
+        },
+      ];
+    }, [] as Tab[]);
+
+  const routes = {
+    value: "clients",
+    title: "Clients",
+    children: newNavItems,
+    afterChildren: (
+      <SelectClientCombobox
+        clients={navItems.clients.filter((c) => !c.override)}
+        onSelect={(id) => console.log(id)}
+        defaultValue=""
+        showLabel={false}
+        placeholder="Add client settings"
+        hideAllClients
+      />
+    ),
+  };
+
+  return [...settingsTabs, routes];
+}
+
+function updateSettingsTabs(settingsTabs: Tab[], navItems: SettingsNavitems) {
+  const groupSettings = addGroupsToSettingsNav(settingsTabs, navItems);
+  const clientSettings = addClientsToSettingsNav(groupSettings, navItems);
+
+  return clientSettings;
+}
+
+function getSelectedPage(settingsTabs: Tab[]) {
+  const page = window.location.hash;
+  const settingsPage = page.replace(/#\/\w+\/?/, "");
+
+  if (!settingsPage) {
+    return settingsTabs[0].value;
+  }
+
+  return settingsPage;
+}
+
+export const BASE_SETTINGS_TABS: Tab[] = [
+  {
+    value: "server",
+    title: "Server",
+  },
+  {
+    value: "mail",
+    title: "Mail",
+  },
+  {
+    value: "ldap-ad",
+    title: "LDAP/AD",
+  },
+  {
+    value: "users",
+    title: "Users",
+  },
+  {
+    value: "general",
+    title: "General",
+    children: [
+      {
+        value: "backups",
+        title: "Backups",
+      },
+      {
+        value: "client",
+        title: "Client",
+      },
+      {
+        value: "archive",
+        title: "Archive",
+      },
+      {
+        value: "alerts",
+        title: "Alerts",
+      },
+      {
+        value: "advanced",
+        title: "Advanced",
+      },
+    ],
+  },
+];

--- a/urbackupserver/www2/src/pages/SettingsPage.tsx
+++ b/urbackupserver/www2/src/pages/SettingsPage.tsx
@@ -1,0 +1,13 @@
+import { Suspense } from "react";
+import { Spinner } from "@fluentui/react-components";
+import { Outlet } from "react-router-dom";
+
+export const SettingsPage = () => {
+  return (
+    <Suspense fallback={<Spinner />}>
+      <div>
+        <Outlet />
+      </div>
+    </Suspense>
+  );
+};


### PR DESCRIPTION
This PR adds the following features:
- Design general layout of the settings page, including:
  - A select box for selecting the client to configure
  - A select box for selecting the group (if there are any)
  - A button to add a new group
 - Components for settings: for string, checkbox, number
 - Server settings
   - with hidden advanced settings
   
##  Screenshots
Settings layout

![localhost_5173_(Small laptop) (1)](https://github.com/user-attachments/assets/bb03ba7b-ac75-46e1-bea1-88386069f8bb)

Hidden advanced settings
![Screenshot from 2025-06-27 08-49-09](https://github.com/user-attachments/assets/053d10a7-0703-4a28-8d12-c67ebba36438)
![Screenshot from 2025-06-27 08-49-23](https://github.com/user-attachments/assets/37bc1c2c-7153-4a77-85da-b5b42d2f7915)

Resettable fields (autosaved if valid)
![Screenshot from 2025-06-27 08-52-49](https://github.com/user-attachments/assets/3906dfba-3b04-4135-9ea7-42c33980442b)
