### PR TITLE
Wake metadata apply thread on forceStart()

### DIFF
--- a/urbackupserver/FileMetadataDownloadThread.cpp
+++ b/urbackupserver/FileMetadataDownloadThread.cpp
@@ -1489,6 +1489,7 @@ void FileMetadataDownloadThread::forceStart()
 {
 	IScopedLock lock(mutex.get());
 	force_start = true;
+	cond->notify_all();
 }
 
 bool FileMetadataDownloadThread::getHasTimeoutError()


### PR DESCRIPTION
The apply thread waits up to 60 s in a condition wait for the file preceding a metadata entry to finish hashing. Nothing signals the condition when that happens or when the backup calls forceStart() at the end, so every file backup ended with an idle ~60 s in "Waiting for file hashing and copying threads". Notify the condition in forceStart() so the apply thread re-checks immediately.
