### PR TITLE
Compare the USN reindex threshold against records, not bytes

### DIFF
--- a/urbackupclient/ChangeJournalWatcher.cpp
+++ b/urbackupclient/ChangeJournalWatcher.cpp
@@ -147,7 +147,10 @@ namespace usn
 	}
 }
 
-const DWORDLONG usn_reindex_num=1000000; // one million
+const DWORDLONG usn_reindex_num=1000000; // one million records
+// USN values are byte offsets into the journal, so NextUsn-last_record is a byte count.
+// Dividing by the smallest possible record gives an upper bound on the pending record count.
+const DWORDLONG usn_min_record_size=sizeof(USN_RECORD);
 
 //#define MFT_ON_DEMAND_LOOKUP
 
@@ -472,9 +475,9 @@ void ChangeJournalWatcher::watchDir(const std::string &dir)
 			needs_reindex=true;
 		}
 
-		if( do_index==false && data.NextUsn-info.last_record>usn_reindex_num )
+		if( do_index==false && (data.NextUsn-info.last_record)/usn_min_record_size>usn_reindex_num )
 		{
-			Server->Log("There are "+convert(data.NextUsn-info.last_record)+" new USN entries at '"+vol+"' - reindexing", LL_WARNING);
+			Server->Log("There are up to "+convert((data.NextUsn-info.last_record)/usn_min_record_size)+" new USN entries at '"+vol+"' - reindexing", LL_WARNING);
 			needs_reindex=true;
 		}
 


### PR DESCRIPTION
usn_reindex_num is documented as one million entries, but it was compared against NextUsn-last_record, which is a byte offset difference in the journal. USN records are 60-120 bytes, so the check reported about 6 million "new USN entries" for 25,000 file creations and forced a full MFT reindex, together with the file-list cache wipe that comes with it. 

Divide the pending byte range by the minimum record size to get an upper bound on the record count before comparing. The journal-wrap case is unchanged: it is still caught by the FirstUsn/NextUsn range check.

Tested on Windows Server 2022: 25,000 files created while the client service was stopped triggered the reindex with the stock client and no reindex with this change.
