### PR TITLE
Do not back up or restore Data Deduplication reparse points

### DIFF
--- a/fileservplugin/FileMetadataPipe.cpp
+++ b/fileservplugin/FileMetadataPipe.cpp
@@ -863,7 +863,8 @@ bool FileMetadataPipe::transmitCurrMetadata( char* buf, size_t buf_avail, size_t
 		}
 
 		if(curr_stream->dwStreamId==BACKUP_DATA
-			|| curr_stream->dwStreamId==BACKUP_SPARSE_BLOCK)
+			|| curr_stream->dwStreamId==BACKUP_SPARSE_BLOCK
+			|| (curr_stream->dwStreamId==BACKUP_REPARSE_DATA && skip_reparse_data) )
 		{
 			//skip
 			LARGE_INTEGER seeked;
@@ -931,9 +932,14 @@ bool FileMetadataPipe::transmitCurrMetadata( char* buf, size_t buf_avail, size_t
 	return false;
 }
 
+#ifndef IO_REPARSE_TAG_DEDUP
+#define IO_REPARSE_TAG_DEDUP (0x80000013L)
+#endif
+
 bool FileMetadataPipe::openFileHandle()
 {
 	backup_read_context = NULL;
+	skip_reparse_data = false;
 	hFile = CreateFileW(Server->ConvertToWchar(os_file_prefix(local_fn)).c_str(), GENERIC_READ | ACCESS_SYSTEM_SECURITY | READ_CONTROL, FILE_SHARE_READ, NULL,
 		OPEN_EXISTING, FILE_FLAG_BACKUP_SEMANTICS | FILE_FLAG_SEQUENTIAL_SCAN | FILE_FLAG_OPEN_REPARSE_POINT, NULL);
 
@@ -944,6 +950,21 @@ bool FileMetadataPipe::openFileHandle()
 	{
 		hFile = CreateFileW(Server->ConvertToWchar(os_file_prefix(local_fn)).c_str(), GENERIC_READ| READ_CONTROL, FILE_SHARE_READ, NULL,
 			OPEN_EXISTING, FILE_FLAG_BACKUP_SEMANTICS | FILE_FLAG_SEQUENTIAL_SCAN | FILE_FLAG_OPEN_REPARSE_POINT, NULL);
+	}
+
+	if (hFile != INVALID_HANDLE_VALUE)
+	{
+		/* Data Deduplication keeps an optimized file's content in the volume's chunk store
+		   and marks the file with a reparse point. The file data is transferred rehydrated,
+		   so the reparse point must not be stored: restoring it would turn the file into a
+		   stub referring to a chunk store that does not exist on the restore target. */
+		FILE_ATTRIBUTE_TAG_INFO tag_info;
+		if (GetFileInformationByHandleEx(hFile, FileAttributeTagInfo, &tag_info, sizeof(tag_info))
+			&& (tag_info.FileAttributes & FILE_ATTRIBUTE_REPARSE_POINT)
+			&& tag_info.ReparseTag == IO_REPARSE_TAG_DEDUP)
+		{
+			skip_reparse_data = true;
+		}
 	}
 
 	return hFile != INVALID_HANDLE_VALUE;

--- a/fileservplugin/FileMetadataPipe.h
+++ b/fileservplugin/FileMetadataPipe.h
@@ -57,6 +57,7 @@ private:
 	LARGE_INTEGER curr_stream_size;
 	int64 curr_pos;
 	std::string stream_name;
+	bool skip_reparse_data;
 #else
 	enum BackupState
 	{

--- a/urbackupclient/FileMetadataDownloadThread.cpp
+++ b/urbackupclient/FileMetadataDownloadThread.cpp
@@ -280,6 +280,10 @@ namespace
 	const size_t metadata_id_size = 4+4+8+4;
 	const int64 win32_meta_magic = little_endian(0x320FAB3D119DCB4A);
 
+#ifndef IO_REPARSE_TAG_DEDUP
+#define IO_REPARSE_TAG_DEDUP (0x80000013L)
+#endif
+
 	class HandleScope
 	{
 	public:
@@ -442,7 +446,33 @@ bool FileMetadataDownloadThread::applyOsMetadata( IFile* metadata_f, const std::
 			data_checksum = urb_adler32(data_checksum, stream_id.data() + metadata_id_size, static_cast<_u32>(curr_stream_id->dwStreamNameSize));
 		}	
 
-		if (hFile != INVALID_HANDLE_VALUE)
+		/* Backups made before the client skipped it may carry a Data Deduplication reparse
+		   point. Its data refers to the source volume's chunk store, so writing it back would
+		   leave the restored file unreadable. Read the stream first to look at its tag. */
+		bool skip_stream = false;
+		std::vector<char> stream_data;
+		if (curr_stream_id->dwStreamId == BACKUP_REPARSE_DATA
+			&& curr_stream_id->Size >= static_cast<int64>(sizeof(_u32))
+			&& curr_stream_id->Size <= 64 * 1024)
+		{
+			stream_data.resize(static_cast<size_t>(curr_stream_id->Size));
+
+			if (metadata_f->Read(stream_data.data(), static_cast<_u32>(stream_data.size())) != stream_data.size())
+			{
+				restore.log("Error reading  \"" + metadata_f->getFilename() + "\" -4", LL_ERROR);
+				has_error = true;
+				break;
+			}
+
+			data_checksum = urb_adler32(data_checksum, stream_data.data(), static_cast<_u32>(stream_data.size()));
+
+			_u32 reparse_tag;
+			memcpy(&reparse_tag, stream_data.data(), sizeof(reparse_tag));
+			skip_stream = (reparse_tag == IO_REPARSE_TAG_DEDUP);
+		}
+
+		if (hFile != INVALID_HANDLE_VALUE
+			&& !skip_stream)
 		{
 			DWORD written = 0;
 			BOOL b = BackupWrite(hFile, reinterpret_cast<LPBYTE>(stream_id.data()), static_cast<DWORD>(stream_id.size()), &written, FALSE, TRUE, &context);
@@ -456,6 +486,25 @@ bool FileMetadataDownloadThread::applyOsMetadata( IFile* metadata_f, const std::
 		}
 
 		int64 curr_pos=0;
+
+		if (!stream_data.empty())
+		{
+			if (hFile != INVALID_HANDLE_VALUE
+				&& !skip_stream)
+			{
+				DWORD written = 0;
+				BOOL b = BackupWrite(hFile, reinterpret_cast<LPBYTE>(stream_data.data()), static_cast<DWORD>(stream_data.size()), &written, FALSE, TRUE, &context);
+
+				if (!b || written != stream_data.size())
+				{
+					restore.log("Error writting metadata to file \"" + output_fn + "\". "+os_last_error_str(), LL_ERROR);
+					has_error = true;
+					break;
+				}
+			}
+
+			curr_pos = static_cast<int64>(stream_data.size());
+		}
 
 		while(curr_pos<curr_stream_id->Size)
 		{


### PR DESCRIPTION
Windows Data Deduplication marks optimized files with an IO_REPARSE_TAG_DEDUP reparse point whose data refers to the volume's chunk store. The client already transfers such files rehydrated, but the metadata pipe opens the file with FILE_FLAG_OPEN_REPARSE_POINT and stores every BackupRead stream except the data streams, so the dedup reparse data ended up in the file's metadata and was written back on restore. A file restored to a volume without deduplication (or a different chunk store) then fails with "The file or directory is corrupted and unreadable" until the reparse point is removed.

Skip the BACKUP_REPARSE_DATA stream at capture time when the file's reparse tag is IO_REPARSE_TAG_DEDUP, and ignore such a stream at restore time so backups made by older clients restore cleanly as well.