### PR TITLE
Multiple download threads fixes

### DIFF
--- a/urbackupserver/FullFileBackup.cpp
+++ b/urbackupserver/FullFileBackup.cpp
@@ -986,8 +986,8 @@ bool FullFileBackup::doFileBackup()
 		}
 	}
 
-	_i64 transferred_bytes=fc.getTransferredBytes();
-	_i64 transferred_compressed=fc.getRealTransferredBytes();
+	_i64 transferred_bytes=fc.getTransferredBytes()+server_download->getTransferredBytes();
+	_i64 transferred_compressed=fc.getRealTransferredBytes()+server_download->getRealTransferredBytes();
 	int64 passed_time=transfer_stop_time-full_backup_starttime;
 	if(passed_time==0) passed_time=1;
 

--- a/urbackupserver/IncrFileBackup.cpp
+++ b/urbackupserver/IncrFileBackup.cpp
@@ -1838,8 +1838,10 @@ bool IncrFileBackup::doFileBackup()
 	running_updater->stop();
 	backup_dao->updateFileBackupRunning(backupid);
 
-	_i64 transferred_bytes=fc.getTransferredBytes()+(fc_chunked.get()?fc_chunked->getTransferredBytes():0);
-	_i64 transferred_compressed=fc.getRealTransferredBytes()+(fc_chunked.get()?fc_chunked->getRealTransferredBytes():0);
+	_i64 transferred_bytes=fc.getTransferredBytes()+(fc_chunked.get()?fc_chunked->getTransferredBytes():0)
+		+server_download->getTransferredBytes();
+	_i64 transferred_compressed=fc.getRealTransferredBytes()+(fc_chunked.get()?fc_chunked->getRealTransferredBytes():0)
+		+server_download->getRealTransferredBytes();
 	int64 passed_time=incr_backup_stoptime-incr_backup_starttime;
 	ServerLogger::Log(logid, "Transferred "+PrettyPrintBytes(transferred_bytes)+" - Average speed: "+PrettyPrintSpeed((size_t)((transferred_bytes*1000)/(passed_time)) ), LL_INFO );
 	if(transferred_compressed>0)

--- a/urbackupserver/ServerDownloadThread.cpp
+++ b/urbackupserver/ServerDownloadThread.cpp
@@ -1162,7 +1162,8 @@ IFsFile * ServerDownloadThread::getTempFile()
 	{
 		size_t num = tmpfile_num++;
 			
-		std::string fn = backuppath + os_file_sep() + tmpfile_dirname + os_file_sep() + convert(num);
+		std::string fn = backuppath + os_file_sep() + tmpfile_dirname + os_file_sep()
+			+ convert(thread_idx) + "_" + convert(num);
 		pfd = Server->openFile(os_file_prefix(fn), MODE_RW_CREATE);
 
 		if (pfd == NULL)
@@ -1174,7 +1175,8 @@ IFsFile * ServerDownloadThread::getTempFile()
 					ServerLogger::Log(logid, "Temporary file path did not exist. Creating it. (ServerDownloadThread)", LL_DEBUG);
 				}
 
-				if (!os_create_dir_recursive(os_file_prefix(backuppath + os_file_sep() + tmpfile_dirname)))
+				if (!os_create_dir_recursive(os_file_prefix(backuppath + os_file_sep() + tmpfile_dirname))
+					&& !os_directory_exists(os_file_prefix(backuppath + os_file_sep() + tmpfile_dirname)))
 				{
 					ServerLogger::Log(logid, "Error creating temporary file path at \""
 						+ backuppath + os_file_sep() + tmpfile_dirname+"\". " + os_last_error_str(), LL_WARNING);

--- a/urbackupserver/ServerDownloadThreadGroup.cpp
+++ b/urbackupserver/ServerDownloadThreadGroup.cpp
@@ -93,6 +93,40 @@ ServerDownloadThreadGroup::~ServerDownloadThreadGroup()
 	}
 }
 
+int64 ServerDownloadThreadGroup::getTransferredBytes()
+{
+	int64 ret = 0;
+	for (size_t i = 0; i < dl_threads.size(); ++i)
+	{
+		if (dl_threads[i].fc != NULL)
+		{
+			ret += dl_threads[i].fc->getTransferredBytes();
+		}
+		if (dl_threads[i].fc_chunked != NULL)
+		{
+			ret += dl_threads[i].fc_chunked->getTransferredBytes();
+		}
+	}
+	return ret;
+}
+
+int64 ServerDownloadThreadGroup::getRealTransferredBytes()
+{
+	int64 ret = 0;
+	for (size_t i = 0; i < dl_threads.size(); ++i)
+	{
+		if (dl_threads[i].fc != NULL)
+		{
+			ret += dl_threads[i].fc->getRealTransferredBytes();
+		}
+		if (dl_threads[i].fc_chunked != NULL)
+		{
+			ret += dl_threads[i].fc_chunked->getRealTransferredBytes();
+		}
+	}
+	return ret;
+}
+
 void ServerDownloadThreadGroup::queueSkip()
 {
 	for (size_t i = 0; i < dl_threads.size(); ++i)

--- a/urbackupserver/ServerDownloadThreadGroup.cpp
+++ b/urbackupserver/ServerDownloadThreadGroup.cpp
@@ -38,8 +38,16 @@ ServerDownloadThreadGroup::ServerDownloadThreadGroup(FileClient& fc, FileClientC
 				curr_fc->setProgressLogCallback(client_main);
 			}
 
-			if (incremental_num > 0 &&
-				intra_file_diffs)
+			//Whether a chunked download gets queued is decided by intra_file_diffs
+			//alone (IncrFileBackup::doFileBackup), and the first thread uses the
+			//FileClientChunked the backup itself created on the same condition. Only
+			//these additional threads also consulted incremental_num, which is a
+			//stand-in for "this is a full backup, so nothing chunked will be queued".
+			//That holds for FullFileBackup, which never queues one, but not for
+			//IncrFileBackup with incremental_num==0 -- a resumed full backup. There
+			//the extra threads got no chunked client while chunked downloads were
+			//still handed to them, and the patch file came out empty.
+			if (intra_file_diffs)
 			{
 				std::auto_ptr<FileClientChunked> new_fc;
 				if (client_main->getClientChunkedFilesrvConnection(new_fc, server_settings, client_main, 60000))

--- a/urbackupserver/ServerDownloadThreadGroup.h
+++ b/urbackupserver/ServerDownloadThreadGroup.h
@@ -53,6 +53,14 @@ public:
 
 	bool join(int waitms);
 
+	//Bytes transferred by the FileClients this group created for the additional
+	//download threads. The first thread uses the FileClient handed to the
+	//constructor, which the caller accounts for itself, so its entry is NULL here
+	//and contributes nothing.
+	int64 getTransferredBytes();
+
+	int64 getRealTransferredBytes();
+
 private:
 	ServerDownloadThread* getMinQueued();
 


### PR DESCRIPTION
1. **Temporary file collisions.** With `use_tmpfiles=false` every `ServerDownloadThread` numbers its temp files from its own counter in the same directory, so two threads pick the same name and the second silently opens the file the first is still writing. Measured on 2.5.38 with `download_threads=4` on a 13.7 GB backup: aborted after 3.1 GB with 252 "Error opening file ... for reading" and "Backup failed because of disk problems". The thread index now goes into the name; the benign "could not create temp dir" race between threads no longer logs a warning.

2. **Transferred bytes under-reported.** Only the first thread's `FileClient` was counted, so "Transferred" and "Average speed" report roughly 1/N. Measured: 370.8 MB with one thread, 90.9 MB reported for the same data with four. The group now sums the clients it owns.

3. **Resumed full backups fail.** The additional threads were only given a chunked client when `incremental_num > 0`, but chunked downloads are queued on `intra_file_diffs` alone. A resumed full (`IncrFileBackup` with `incremental_num == 0`) handed them chunked downloads with no client, the patch file stayed empty and the backup died with "Error reading patched file size". Decide on `intra_file_diffs`, the same condition the queueing and the first thread use.

13.7GB 20,000 file test case
Before: 
 1 thread
 backup time 266 s
 CPU time 210 s

After: 
 4 threads
 backup time: 90s
 CPU time: 231 s