### PR TITLE
Compact TreeNode from 72 to 48 bytes

### DIFF
--- a/urbackupserver/treediff/TreeDiff.cpp
+++ b/urbackupserver/treediff/TreeDiff.cpp
@@ -75,8 +75,6 @@ void TreeDiff::gatherDiffs(TreeNode *t1, TreeNode *t2, size_t depth, std::vector
 	std::vector<size_t> *modified_inplace_ids, std::vector<size_t> &dir_diffs,
 	std::vector<size_t> *deleted_inplace_ids, bool has_symbit, bool is_windows)
 {
-	size_t nc_2=t2->getNumChildren();
-	size_t nc_1=t1->getNumChildren();
 	TreeNode *c2=t2->getFirstChild();
 	TreeNode *c1=t1->getFirstChild();
 	bool did_subtree_change=false;
@@ -110,7 +108,7 @@ void TreeDiff::gatherDiffs(TreeNode *t1, TreeNode *t2, size_t depth, std::vector
 			{
 				if (c2->getType() == sn->getType()
 					&& c2->nameEquals(*sn)
-					&& sn->getMappedNode()==NULL)
+					&& !sn->isMapped())
 				{
 					cmp = 0;
 					c1 = sn;
@@ -136,8 +134,8 @@ void TreeDiff::gatherDiffs(TreeNode *t1, TreeNode *t2, size_t depth, std::vector
 			{
 				gatherDiffs(c1, c2, depth+1, diffs, modified_inplace_ids, 
 					dir_diffs, deleted_inplace_ids, has_symbit, is_windows);
-				c2->setMappedNode(c1);
-				c1->setMappedNode(c2);
+				c2->setMapped(true);
+				c1->setMapped(true);
 			}
 			else
 			{
@@ -196,7 +194,7 @@ void TreeDiff::gatherDeletes(TreeNode *t1, std::vector<size_t> &deleted_ids)
 	TreeNode *c1=t1->getFirstChild();
 	while(c1!=NULL)
 	{
-		if(c1->getMappedNode()==NULL)
+		if(!c1->isMapped())
 		{
 			deleted_ids.push_back(c1->getId());
 		}
@@ -233,7 +231,7 @@ void TreeDiff::gatherLargeUnchangedSubtrees( TreeNode *t2, std::vector<size_t> &
 	while(c2!=NULL)
 	{
 		if(!c2->getSubtreeChanged()
-			&& c2->getMappedNode()!=NULL
+			&& c2->isMapped()
 			&& getTreesize(c2,10)>10)
 		{
 			large_unchanged_subtrees.push_back(c2->getId());

--- a/urbackupserver/treediff/TreeNode.cpp
+++ b/urbackupserver/treediff/TreeNode.cpp
@@ -22,14 +22,14 @@
 #include <string.h>
 
 TreeNode::TreeNode(const char* name, const char* data, TreeNode *parent, char node_type)
-	: name(name), data(data), parent(parent), num_children(0), nextSibling(NULL), mapped_node(NULL),
-	  subtree_changed(false), node_type(node_type), id(0)
+	: name(name), data(data), nextSibling(NULL), parent(parent), id(0),
+	  node_type(node_type), has_children(false), mapped(false), subtree_changed(false)
 {
 }
 
 TreeNode::TreeNode(void)
-	: num_children(0), nextSibling(NULL), mapped_node(NULL), subtree_changed(false), parent(NULL),
-	name(NULL), data(NULL), node_type(0), id(0)
+	: name(NULL), data(NULL), nextSibling(NULL), parent(NULL), id(0),
+	  node_type(0), has_children(false), mapped(false), subtree_changed(false)
 {
 }
 
@@ -72,14 +72,9 @@ void TreeNode::setData(const char* pData)
 	data=pData;
 }
 
-size_t TreeNode::getNumChildren()
-{
-	return num_children;
-}
-
 TreeNode* TreeNode::getFirstChild(void)
 {
-	if(num_children>0)
+	if(has_children)
 	{
 		return this+1;
 	}
@@ -94,9 +89,9 @@ void TreeNode::setNextSibling(TreeNode *pNextSibling)
 	nextSibling=pNextSibling;
 }
 
-void TreeNode::incrementNumChildren(void)
+void TreeNode::setHasChildren(void)
 {
-	++num_children;
+	has_children=true;
 }
 
 void TreeNode::setId(size_t pId)
@@ -143,14 +138,14 @@ TreeNode *TreeNode::getParent(void)
 	return parent;
 }
 
-TreeNode *TreeNode::getMappedNode()
+bool TreeNode::isMapped()
 {
-	return mapped_node;
+	return mapped;
 }
 
-void TreeNode::setMappedNode(TreeNode *pMappedNode)
+void TreeNode::setMapped(bool b)
 {
-	mapped_node=pMappedNode;
+	mapped=b;
 }
 
 void TreeNode::setSubtreeChanged( bool b )

--- a/urbackupserver/treediff/TreeNode.h
+++ b/urbackupserver/treediff/TreeNode.h
@@ -27,11 +27,10 @@ public:
 	int nameCompare(const TreeNode& other);
 	bool dataEquals(const TreeNode& other);
 
-	size_t getNumChildren();
 	TreeNode* getFirstChild(void);
 	void setNextSibling(TreeNode *pNextSibling);
 	TreeNode *getNextSibling(void);
-	void incrementNumChildren(void);
+	void setHasChildren(void);
 	TreeNode* getChild(size_t n);
 	void setParent(TreeNode *pParent);
 	TreeNode *getParent(void);
@@ -42,8 +41,8 @@ public:
 	void setId(size_t pId);
 	size_t getId(void) const;
 
-	TreeNode *getMappedNode();
-	void setMappedNode(TreeNode *pMappedNode);
+	bool isMapped();
+	void setMapped(bool b);
 
 	void setSubtreeChanged(bool b);
 	bool getSubtreeChanged();
@@ -51,18 +50,19 @@ public:
 	size_t getDataSize();
 
 private:
-	char node_type;
-
 	const char* name;
 	const char* data;
 
 	TreeNode *nextSibling;
 	TreeNode *parent;
-	TreeNode *mapped_node;
-	size_t num_children;
-	bool subtree_changed;
 
 	size_t id;
+
+	/* byte-sized members last: keeps the node at 48 bytes on 64-bit */
+	char node_type;
+	bool has_children;
+	bool mapped;
+	bool subtree_changed;
 };
 
 

--- a/urbackupserver/treediff/TreeReader.cpp
+++ b/urbackupserver/treediff/TreeReader.cpp
@@ -308,7 +308,7 @@ bool TreeReader::readTree(const std::string &fn)
 
 							if(!parents.empty())
 							{
-								parents.top()->incrementNumChildren();
+								parents.top()->setHasChildren();
 								nodes[idx].setParent(parents.top());
 							}
 


### PR DESCRIPTION
`mapped_node` is only ever set non-NULL and tested for NULL, and `num_children` is only ever compared against zero, so both become bools; grouping the byte-sized members after the pointer-sized ones removes the padding. `sizeof(TreeNode)` drops from 72 to 48 bytes on 64-bit, about 46 MiB less per million file-list entries per running incremental. Also drops two unused locals in `gatherDiffs`.

Diff output is unchanged, verified by checksumming the diff results over real file lists before and after. Peak memory of the file-list diff at about 5M entries: 890 MB down to 660 MB.
